### PR TITLE
Updated empty example project_{device}.js files

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,16 @@ In general, the .project folder inside the new example should look similar to be
 
 This file uses 2 functions: getComponentProperty() and getComponentBuildProperty() where user can provide different values as per their requirements to build a PRU project of our choice, some of which are discussed as follows.
 
-- Change the name of the project by modifying the value property.name .
+- Change the name of the project by modifying the value project_name
+   - An example is given below
+      ```
+      let project_name = "new_example";
+      ```
 - Add a description for the project by modifying the value property.description . 
    - An example is given below
-          ```
-          property.name = "new_example";
-          property.description = "new example PRU Project"
-          ```
+      ```
+      property.description = "new example PRU Project";
+      ```
 - Provide the different build option combos, by modifying the value of property.buildOptionCombos. It takes in an array of JavaScript objects wherein one can specify the device, cpu, cgt, board and os. An example array of build option combos is given below.
    ```
    const buildOptionCombos = [

--- a/examples/empty/firmware/.project/project_am243x.js
+++ b/examples/empty/firmware/.project/project_am243x.js
@@ -2,6 +2,8 @@ let path = require('path');
 
 let device = "am243x";
 
+let project_name = "empty";
+
 const files = {
     common: [
         "main.asm",
@@ -90,7 +92,7 @@ function getmakefilePruPostBuildSteps(cpu, board)
             core = "PRU0"
     }
     return  [
-        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + "empty" + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
+        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + project_name + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
         "$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
         "$(RM) "+ core.toLocaleLowerCase() + "_load_bin.h;"
     ]; 
@@ -121,7 +123,7 @@ function getccsPruPostBuildSteps(cpu, board)
             core = "PRU0"
     }
     return  [
-        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + "empty" + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
+        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + project_name + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
         "if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
         "if ${CCS_HOST_OS} == linux rm "+ core.toLocaleLowerCase() + "_load_bin.h;"+
         "if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
@@ -135,7 +137,7 @@ function getComponentProperty() {
     property.dirPath = path.resolve(__dirname, "..");
     property.type = "executable";
     property.makefile = "pru";
-    property.name = "empty";
+    property.name = project_name;
     property.isInternal = false;
     property.description = "Empty PRU Project"
     property.buildOptionCombos = buildOptionCombos;

--- a/examples/empty/firmware/.project/project_am261x.js
+++ b/examples/empty/firmware/.project/project_am261x.js
@@ -2,6 +2,8 @@ let path = require('path');
 
 let device = "am261x";
 
+let project_name = "empty";
+
 const files = {
     common: [
         "main.asm",
@@ -71,7 +73,7 @@ function getmakefilePruPostBuildSteps(cpu, board)
     }
 
     return  [
-        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + "empty" + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
+        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + project_name + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
         "$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
         "$(RM) "+ core.toLocaleLowerCase() + "_load_bin.h;"
     ]; 
@@ -91,7 +93,7 @@ function getccsPruPostBuildSteps(cpu, board)
     }
 
     return [
-        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + "empty" + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
+        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + project_name + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
         "if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
         "if ${CCS_HOST_OS} == linux rm "+ core.toLocaleLowerCase() + "_load_bin.h;"+
         "if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
@@ -105,7 +107,7 @@ function getComponentProperty() {
     property.dirPath = path.resolve(__dirname, "..");
     property.type = "executable";
     property.makefile = "pru";
-    property.name = "empty";
+    property.name = project_name;
     property.isInternal = false;
     property.description = "Empty PRU Project"
     property.buildOptionCombos = buildOptionCombos;

--- a/examples/empty/firmware/.project/project_am263px.js
+++ b/examples/empty/firmware/.project/project_am263px.js
@@ -2,6 +2,8 @@ let path = require('path');
 
 let device = "am263px";
 
+let project_name = "empty";
+
 const files = {
     common: [
         "main.asm",
@@ -71,7 +73,7 @@ function getmakefilePruPostBuildSteps(cpu, board)
     }
 
     return  [
-        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + "empty" + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
+        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + project_name + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
         "$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
         "$(RM) "+ core.toLocaleLowerCase() + "_load_bin.h;"
     ]; 
@@ -91,7 +93,7 @@ function getccsPruPostBuildSteps(cpu, board)
     }
 
     return [
-        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + "empty" + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
+        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + project_name + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
         "if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
         "if ${CCS_HOST_OS} == linux rm "+ core.toLocaleLowerCase() + "_load_bin.h;"+
         "if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
@@ -106,7 +108,7 @@ function getComponentProperty() {
     property.dirPath = path.resolve(__dirname, "..");
     property.type = "executable";
     property.makefile = "pru";
-    property.name = "empty";
+    property.name = project_name;
     property.isInternal = false;
     property.description = "Empty PRU Project"
     property.buildOptionCombos = buildOptionCombos;

--- a/examples/empty/firmware/.project/project_am263x.js
+++ b/examples/empty/firmware/.project/project_am263x.js
@@ -2,6 +2,8 @@ let path = require('path');
 
 let device = "am263x";
 
+let project_name = "empty";
+
 const files = {
     common: [
         "main.asm",
@@ -71,7 +73,7 @@ function getmakefilePruPostBuildSteps(cpu, board)
     }
 
     return  [
-        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + "empty" + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
+        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + project_name + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
         "$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
         "$(RM) "+ core.toLocaleLowerCase() + "_load_bin.h;"
     ]; 
@@ -91,7 +93,7 @@ function getccsPruPostBuildSteps(cpu, board)
     }
 
     return [
-        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + "empty" + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
+        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + project_name + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
         "if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
         "if ${CCS_HOST_OS} == linux rm "+ core.toLocaleLowerCase() + "_load_bin.h;"+
         "if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
@@ -105,7 +107,7 @@ function getComponentProperty() {
     property.dirPath = path.resolve(__dirname, "..");
     property.type = "executable";
     property.makefile = "pru";
-    property.name = "empty";
+    property.name = project_name;
     property.isInternal = false;
     property.description = "Empty PRU Project"
     property.buildOptionCombos = buildOptionCombos;

--- a/examples/empty/firmware/.project/project_am64x.js
+++ b/examples/empty/firmware/.project/project_am64x.js
@@ -2,6 +2,8 @@ let path = require('path');
 
 let device = "am64x";
 
+let project_name = "empty";
+
 const files = {
     common: [
         "main.asm",
@@ -73,7 +75,7 @@ function getmakefilePruPostBuildSteps(cpu, board)
             core = "PRU0"
     }
     return  [
-        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + "empty" + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
+        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + project_name + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
         "$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
         "$(RM) "+ core.toLocaleLowerCase() + "_load_bin.h;"
     ]; 
@@ -104,7 +106,7 @@ function getccsPruPostBuildSteps(cpu, board)
             core = "PRU0"
     }
     return  [
-        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + "empty" + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
+        "$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix="+ core + "Firmware  -o "+ core.toLocaleLowerCase() + "_load_bin.h " + project_name + "_" + board + "_" + cpu + "_fw_ti-pru-cgt.out;"+ 
         "if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
         "if ${CCS_HOST_OS} == linux rm "+ core.toLocaleLowerCase() + "_load_bin.h;"+
         "if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h "+ core.toLocaleLowerCase() + "_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/"+ board + "/" +core.toLocaleLowerCase() + "_load_bin.h ;"+ 
@@ -127,7 +129,7 @@ function getComponentProperty() {
     property.dirPath = path.resolve(__dirname, "..");
     property.type = "executable";
     property.makefile = "pru";
-    property.name = "empty";
+    property.name = project_name;
     property.isInternal = false;
     property.description = "Empty PRU Project"
     property.buildOptionCombos = buildOptionCombos;


### PR DESCRIPTION
The user is told to copy the project_{device}.js file from the /examples/empty/firmware directory  when creating a new PRU project, however "empty" is hard coded in post build steps -- leading to conflicts when attempting to build and run. I changed this from "empty" to property.name which the user is instructed to change when making their new project.