### PR TITLE
README: split off getting_started page, reword & reorganize

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,199 +3,60 @@
 <img src="https://upload.wikimedia.org/wikipedia/commons/b/ba/TexasInstruments-Logo.svg" width="150"><br/>
 # OPEN PRU
 
-[Introduction](#introduction) | [Features](#features) | [Overview](#overview) | [Learn](#learn) | [Usage](#usage) | [Contribute](#contributing-to-the-project)
+[Introduction](#introduction) | [Features](#features) | [Getting Started](#getting-started) | [Building the examples](#building-the-examples) | [Information about using EVM boards](#information-about-using-evm-boards) | [Steps to add a new OPEN PRU project](#steps-to-add-a-new-open-pru-project) | [Contributing to the OPEN PRU project](#contributing-to-the-open-pru-project) | [Technical Support](#technical-support)
 
 </div>
 
 ## Introduction
 
-OPEN PRU is a software development package designed for usage with the PRU processor from Texas Instruments Sitara devices and Jacinto class of devices. These devices currently include:
+OPEN PRU is a software development package that enables development on the PRU processor core. PRU cores are included in Texas Instruments (TI) Sitara devices and Jacinto class of devices.
 
-- [AM2431](https://www.ti.com/product/AM2431), [AM2432](https://www.ti.com/product/AM2432), [AM2434](https://www.ti.com/product/AM2434)
-- [AM6411](https://www.ti.com/product/AM6411), [AM6412](https://www.ti.com/product/AM6412), [AM6421](https://www.ti.com/product/AM6421), [AM6422](https://www.ti.com/product/AM6422), [AM6441](https://www.ti.com/product/AM6441), [AM6442](https://www.ti.com/product/AM6442).
-- [AM2612](https://www.ti.com/product/AM2612)
-- [AM263P2-Q1](https://www.ti.com/product/AM263P2-Q1), [AM263P2](https://www.ti.com/product/AM263P2), [AM263P4-Q1](https://www.ti.com/product/AM263P4-Q1), [AM263P4](https://www.ti.com/product/AM263P4)
-- [AM2631](https://www.ti.com/product/AM2631), [AM2631-Q1](https://www.ti.com/product/AM2631-Q1), [AM2632](https://www.ti.com/product/AM2632), [AM2631-Q1](https://www.ti.com/product/AM2632-Q1), [AM2634](https://www.ti.com/product/AM2634), [AM2634-Q1](https://www.ti.com/product/AM2634-Q1)
+The OPEN PRU project currently supports these processors:
 
-OPEN PRU is designed with user experience and simplicity in mind. The repository includes out-of-box Getting started PRU labs, Macro definitions and application examples.
+- AM243x: [AM2431](https://www.ti.com/product/AM2431), [AM2432](https://www.ti.com/product/AM2432), [AM2434](https://www.ti.com/product/AM2434)
+- AM261x: [AM2612](https://www.ti.com/product/AM2612)
+- AM263x: [AM2631](https://www.ti.com/product/AM2631), [AM2631-Q1](https://www.ti.com/product/AM2631-Q1), [AM2632](https://www.ti.com/product/AM2632), [AM2631-Q1](https://www.ti.com/product/AM2632-Q1), [AM2634](https://www.ti.com/product/AM2634), [AM2634-Q1](https://www.ti.com/product/AM2634-Q1)
+- AM263px: [AM263P2-Q1](https://www.ti.com/product/AM263P2-Q1), [AM263P2](https://www.ti.com/product/AM263P2), [AM263P4-Q1](https://www.ti.com/product/AM263P4-Q1), [AM263P4](https://www.ti.com/product/AM263P4)
+- AM64x: [AM6411](https://www.ti.com/product/AM6411), [AM6412](https://www.ti.com/product/AM6412), [AM6421](https://www.ti.com/product/AM6421), [AM6422](https://www.ti.com/product/AM6422), [AM6441](https://www.ti.com/product/AM6441), [AM6442](https://www.ti.com/product/AM6442).
+
+For basic PRU development support on AM335x, AM437x, AM57x, and AM62x, refer to the [PRU Software Support Package (PSSP)](https://git.ti.com/cgit/pru-software-support-package/pru-software-support-package).
 
 ## Features
 
-- Out of Box Getting started labs, Macro definitions and application Examples
-  - [PRU Academy](./pru_academy): Task manager, Interrupt controller, Broadside accelerator, Labs etc.,
-  - [Application examples](./examples): ADC, SENT, I2C, I2S etc.,
-  - [Macro definitions](./source) of PRUSS, PRUICSSM, PRUICSSG components
+The OPEN PRU project provides:
+  - [PRU Academy](./academy)
+    - PRU Getting Started Labs (project creation, coding in assembly & C, compiling, loading PRU code, debugging PRU code)
+    - Training labs (GPIO, interrupt controller, broadside accelerators, etc.)
+  - [Application examples](./examples)
+    - These PRU examples can be used as a foundation for your design: I2S, SPI, I2C, ADC, etc.
+  - [Helpful software tools](./source)
+    - firmware macros
+    - register definitions
+    - example drivers
 
-## Usage
+## Getting Started
 
-### Prerequisites
+Please follow the [Getting started steps](./getting_started.md) to install dependencies and properly set up the OPEN PRU repository.
 
-#### Supported HOST environments
+## Building the examples 
 
-- Validated on Windows 10 64bit, higher versions may work
-- Validated on Ubuntu 18.04 64bit, higher versions may work
-
-#### Windows environment
-
-**On Windows the dependencies can be manually installed or with the script `pru_dependencies.bat`**
-
-* With Script (AM243x & AM64x only)
-
-   **NOTES**
-   - By default, the script checks for and installs MCU+ SDK 11.0. In order to use a different SDK version, edit the **version numbers** in pru_dependencies.bat to match the versions listed in the MCU+ SDK docs > Getting Started > Download, Install, and Setup sections.
-   - If the script is executed from any folder but `C:\ti`, it will be copied to `C:\ti` after running it and a second terminal screen will be opened with the location of the script. Please re-run script in the new terminal screen
-   - If OpenSSL is needed to be installed, when prompted select option to install binaries to /bin folder of installed path instead of Windows system path
-   - If after installing the dependencies the script is executed to verify the installed, it will show the same missing dependencies. 
-   The used terminal must be closed and re-opened to get the updated state (or PC must be restarted). This is a Windows limitation
-
-   1. It is recommended to verify the dependencies that are already installed. Run the command `pru_dependencies.bat -v`, `pru_dependencies.bat -V` or `pru_dependencies.bat verify`
-
-   2. To install the dependencies, run the command `pru_dependencies.bat -I [dependencies]`, `pru_dependencies.bat -i [dependencies]` or `pru_dependencies.bat install [dependencies]`
-
-   3. To get an assistance on how to use the script, run the command `pru_dependencies.bat -h` or `pru_dependencies.bat help`
-* Manual steps
-
-   1. Download and install Code Composer Studio v12.8 from [here](https://www.ti.com/tool/download/CCSTUDIO "Code Composer Studio")
-      - Install at default folder: C:\ti
-
-   2. Download and install SysConfig 1.21.0 from [here](https://www.ti.com/tool/download/SYSCONFIG "SYSCONFIG 1.21.0")
-      - Install at default folder: C:/ti
-
-   3. Download and install the PRU compiler
-      - [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt)
-      - Install at default folder: C:/ti
-
-   4. Download and install GCC for Cortex A53 (required only for AM64x developers)
-      - [GNU-A](https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-mingw-w64-i686-aarch64-none-elf.tar.xz)
-      - [GNU-RM](https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-win32.zip)
-      - Install at default folder: C:/ti
-
-   5. Download and install Node.js v12.18.4 LTS
-      - Go to the [NodeJS Website](https://nodejs.org/en/) and use the installer to
-      download and install v12.18.4 of node. Install in the default directory.
-      - After successful installation, run an `npm ci` inside the `open-pru` folder like so:
-         ```bash
-         $ cd open-pru/
-         $ npm ci
-         ```
-      - To specify a proxy server, use the --proxy option followed by the proxy server link, like this: --proxy = <proxy server link>
-      This should install the node packages required for the open-pru.
-
-#### Linux environment
-**On Linux the dependencies can be manually installed or with the script `pru_dependencies.sh`**
-
-* With Script (AM243x & AM64x only)
-
-   **NOTES**
-   - By default, the script checks for and installs MCU+ SDK 11.0. In order to use a different SDK version, edit the **version numbers** in pru_dependencies.sh to match the versions listed in the MCU+ SDK docs > Getting Started > Download, Install, and Setup sections.
-   - If the script is executed from any folder but `${HOME}/ti`, it will be copied to `${HOME}/ti` and executed from there automatically
-
-   1. It is recommended to verify the dependencies that are already installed. Run the command `./pru_dependencies.sh -v`, `./pru_dependencies.sh -V` or `./pru_dependencies.sh verify`
-
-   2. To install the dependencies, run the command `./pru_dependencies.sh -I [dependencies]`, `./pru_dependencies.sh -i [dependencies]` or `./pru_dependencies.sh install [dependencies]`
-
-   3. To get an assistance on how to use the script, run the command `./pru_dependencies.sh -h` or `./pru_dependencies.sh help`
-* Manual steps
-
-   1. Download and install Code Composer Studio v12.8 from [here](https://www.ti.com/tool/download/CCSTUDIO "Code Composer Studio")
-      - Install at default folder: ${HOME}/ti
-      - Some dependencies shall be installed before installing CCS. Use the command `sudo apt -y install libc6:i386 libusb-0.1-4 libgconf-2-4 libncurses5 libpython2.7 libtinfo5 build-essential` to install them.
-
-   2. Download and install SysConfig 1.21.0 from [here](https://www.ti.com/tool/download/SYSCONFIG "SYSCONFIG 1.21.0")
-      - Install at default folder: ${HOME}/ti
-
-   3. Download and install the PRU compiler
-      - [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt)
-      - Install at default folder: ${HOME}/ti
-
-   4. Download and install GCC for Cortex A53 (required only for AM64x developers)
-      - [GNU-A](https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-elf.tar.xz)
-      - [GNU-RM](https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2)
-      - Install at default folder: ${HOME}/ti
-
-   5. Install Mono Runtime (required for creating bootloader images for application binaries)
-      - To install, use the command `sudo apt install mono-runtime`
-
-   6. Download and install Node.js v12.18.4 LTS
-      - Go to the [NodeJS Website](https://nodejs.org/en/) and use the installer to
-      download and install v12.18.4 of node. Install in the default directory.
-      - After successful installation, run an `npm ci` inside the `open-pru` folder like so:
-         ```bash
-         $ cd open-pru/
-         $ npm ci
-         ```
-      - To specify a proxy server, use the --proxy option followed by the proxy server link, like this: --proxy = <proxy server link>
-      This should install the node packages required for the open-pru.
-
-## Overview
-
-The MCU+ SDK is a dependency when building OPEN PRU projects that include code for an MCU+ core. Users can either use the Prebuilt SDK installers for specific devices or clone the MCU+ SDK repository in `C:\ti` (Windows environment) or ${HOME}/ti (Linux environment).
-
----
-**NOTE**
-- Use `gmake` in windows, add path to gmake present in CCS at `C:\ti\ccsxxxx\ccs\utils\bin` to your windows PATH. We have
-  used `make` in below instructions.
+**NOTES**
+- Use `gmake` in Windows, and `make` in Linux. gmake is present in CCS. Add the path to the CCS gmake at `C:\ti\ccsxxxx\ccs\utils\bin` to your windows PATH.
 - Unless mentioned otherwise, all `make` commands are invoked from the root folder of the `open-pru` repository.
    ```bash
    cd open-pru/
    ```
-- Current supported device names are am64x, am243x, am261x, am263px, am263x
+- Current supported device names are am243x, am261x, am263x, am263px, am64x
 - Pass one of these values for `"DEVICE="`
 - You can also build components (examples, tests or libraries) in the `release` or `debug`
   profiles. To do this pass one of these values for `"PROFILE="`
----
 
-#### Option 1: Prebuilt SDK installers for specific devices are available at below links. Please note that installers are packaged specifically to each device to reduce size.
-Please use the links below to download the installers:
-   - [AM243x MCU+ SDK](https://www.ti.com/tool/MCU-PLUS-SDK-AM243X)
-   - [AM64x  MCU+ SDK](https://www.ti.com/tool/MCU-PLUS-SDK-AM64X)
-   - [AM261x MCU+ SDK](https://www.ti.com/tool/MCU-PLUS-SDK-AM261X)
-   - [AM263Px MCU+ SDK](https://www.ti.com/tool/MCU-PLUS-SDK-AM263PX)
-   - [AM263x MCU+ SDK](https://www.ti.com/tool/MCU-PLUS-SDK-AM263X)  
+### Basic Building With Makefiles
 
-It is possible also to use the script:
-- For AM243x: run the command `pru_dependencies.bat -I --am243x_sdk`, `pru_dependencies.bat -i --am243x_sdk` or `pru_dependencies.bat install --am243x_sdk` (Windows environment) or
-`./pru_dependencies.sh -I --am243x_sdk`, `./pru_dependencies.sh -i --am243x_sdk` or `./pru_dependencies.sh install --am243x_sdk` (Linux environment)
+#### Build a single project
 
-- For AM64x: run the command `pru_dependencies.bat -I --am64xx_sdk`, `pru_dependencies.bat -i --am64xx_sdk` or `pru_dependencies.bat install --am64xx_sdk` (Windows environment) or
-`./pru_dependencies.sh -I --am64xx_sdk`, `./pru_dependencies.sh -i --am64xx_sdk` or `./pru_dependencies.sh install --am64xx_sdk` (Linux environment)
-
-   ```bash
-   make gen-buildfiles DEVICE=am64x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH>
-   make gen-buildfiles DEVICE=am243x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH>
-   make gen-buildfiles DEVICE=am261x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH>
-   make gen-buildfiles DEVICE=am263px MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH>
-   make gen-buildfiles DEVICE=am263x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH>
-   ```
-
-#### Option 2: MCU+ SDK repository is core for all the Sitara MCU and MPU devices, checkout README.md to clone
-Please use the link below to clone the repository:
-- [MCU PLUS SDK](https://github.com/TexasInstruments/mcupsdk-core)
-
-It is possible also to use the script:
-- run the command `pru_dependencies.bat -I --clone_sdk`, `pru_dependencies.bat -i --clone_sdk` or `pru_dependencies.bat install --clone_sdk` (Windows environment) or
-`./pru_dependencies.sh -I --clone_sdk`, `./pru_dependencies.sh -i --clone_sdk` or `./pru_dependencies.sh install --clone_sdk` (Linux environment)
-
-   ```bash
-   make gen-buildfiles DEVICE=am64x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH> GEN_BUILDFILES_TARGET=development 
-   make gen-buildfiles DEVICE=am243x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH> GEN_BUILDFILES_TARGET=development
-   make gen-buildfiles DEVICE=am261x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH> GEN_BUILDFILES_TARGET=development
-   make gen-buildfiles DEVICE=am263px MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH> GEN_BUILDFILES_TARGET=development
-   make gen-buildfiles DEVICE=am263x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH> GEN_BUILDFILES_TARGET=development
-   ```
-
-## Learn
-
-TI has a large collection of tutorials as part of PRU Academy to help you get started.
-
-- [PRU getting_started](./pru_academy/getting_started)
-
-### Building the examples 
-
-#### Basic Building With Makefiles
-
-1. Make sure to build the PRU firmware before attempting to build an example. For example,
-   to build a PRU firmware for empty example of AM243x, run the following:
+Make sure to build the PRU firmware before building the associated RTOS / bare metal code. For example,
+to build an AM243x PRU firmware example for the "empty" project, run the following:
    ```bash
 	make -s -C examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt     all 
 	make -s -C examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt     all 
@@ -204,32 +65,48 @@ TI has a large collection of tutorials as part of PRU Academy to help you get st
 	make -s -C examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt  all
 	make -s -C examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt  all
    ```
-   Once the PRU Firmware build is complete, Firmware header files of PRU are moved to R5F default include path, to build R5F example run:
+Once the PRU Firmware build is complete, the PRU firmware header files are moved to a location included in the R5F default include path. The PRU firmware will get bundled into the R5F output binary.
+   
+To build the R5F example, run:
    ```bash
    make -s -C examples/empty/am243x-lp/r5fss0-0_freertos/ti-arm-clang all PROFILE=debug
    ```
 
-2. Following are the commands to build **all examples**. Valid PROFILE's are "release" or "debug"
+#### Build all projects
+
+Run these commands to build **all projects** in the OPEN PRU repo. Valid PROFILE options are "release" or "debug":
 
    ```bash
    make -s -j4 clean DEVICE=am243x PROFILE=debug
    make -s -j4 all   DEVICE=am243x PROFILE=debug
    ```
 
-#### Basic Building With CCS
+### Basic Building With CCS
 
-- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU, After this `main.asm`, `linker.cmd` files get copied to ccs workspace of PRU project.
+- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU. After this `main.asm`, `linker.cmd` files get copied to ccs workspace of PRU project.
 
-- Build the PRU project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html)).
-     - Build Flow: Once you click on build in PRU project, firmware header file which is generated in release or debug folder of ccs workspace, is moved to  `<open-pru/examples/pru_io/empty/firmware/device/>`
+- Build the PRU project using the CCS project menu. Refer to **the MCU+ SDK documentation > Using SDK with CCS Projects**:
+  - [AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html)
+  - [AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html)
+  - [AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html)
+  - [AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)
+  - [AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html)
 
-- Build the R5F project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html)).
-     - Firmware header file path is included in R5F project include options by default, Instructions in Firmware header file can be written into PRU IRAM memory using PRUICSS_loadFirmware API (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe))
-     - Build Flow: Once you click on build in R5F project, SysConfig files are generated, Finally the R5F project will be generated using both the generated SysConfig and PRU project binaries.
+#### Build the PRU firmware
 
-### More information on Board usage
+- Once you click on **build** in the PRU project, the PRU firmware header file is generated in the CCS release or debug folder. The PRU header file is moved to  `<open-pru/examples/pru_io/empty/firmware/device/>`
 
-For more details on Board usage, please refer to the Getting started section of MCU+ SDK README_FIRST_*.html page. User guides contain information on
+#### Build the R5F firmware
+
+- Build the R5F project using the CCS project menu. For more details, refer to **the MCU+ SDK documentation > Using SDK with CCS Projects** linked above.
+
+- The PRU Firmware header file path is included in the R5F project include options by default.
+
+- Build Flow: Once you click on build in the R5F project, SysConfig files are generated. Then the R5F project will be generated using both the generated SysConfig files, and PRU project binaries.
+
+## Information about using EVM boards
+
+For more details on EVM Board usage, please refer to the Getting started section of MCU+ SDK README_FIRST_*.html page. The MCU+ SDK User guides contain information on
   
 - EVM setup
 - CCS Setup, loading and running examples
@@ -244,15 +121,9 @@ Getting started guides of MCU+ SDK are specific to a particular device. The link
 - [AM263Px Getting Started Guide](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/GETTING_STARTED.html)
 - [AM263x Getting Started Guide](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/GETTING_STARTED.html)
 
-## Technical Support
+## Steps to add a new OPEN PRU project
 
-Please consider creating a post on [TI's E2E forum](https://e2e.ti.com/).
-
-## Contributing to the project
-
-### Steps to add new example in open-pru repository
-
-#### Step 1 : create .project folder inside new_example folder 
+### Step 1 : create .project folder inside new_example folder 
 
 This folder contains the following files:
 
@@ -265,7 +136,7 @@ In general, the .project folder inside the new example should look similar to be
 
 <img src="./images/readme/fig1.png" width="600"><br/>
 
-#### Step 2 : Modify the contents of the project_{device}.js
+### Step 2 : Modify the contents of the project_{device}.js
 
 This file uses 2 functions: getComponentProperty() and getComponentBuildProperty() where user can provide different values as per their requirements to build a PRU project of our choice, some of which are discussed as follows.
 
@@ -326,7 +197,7 @@ This file uses 2 functions: getComponentProperty() and getComponentBuildProperty
       ],
    };
    ```
-#### Step 3 : Add the path of the project.js file to the respective device's examples file list
+### Step 3 : Add the path of the project.js file to the respective device's examples file list
 
 The path to the project.js of the new project needs to be added to the example file list of the required device. Go to open_pru/.project/device/project_{device}.js and add the path to the project.js of the new example to the example_file_list array.
 
@@ -334,11 +205,11 @@ The path to the project.js of the new project needs to be added to the example f
 
 <img src="./images/readme/fig2.png" width="600"><br/>
 
-#### Step 4 : Generate build files
+### Step 4 : Generate build files
 
 - Run one of the below command from the root folder of open-pru
 
-##### Option 1: Prebuilt MCU PLUS SDK installers for specific devices are used
+#### Option 1: Prebuilt MCU PLUS SDK installers for specific devices are used
    ```bash
    make gen-buildfiles DEVICE={device} 
    ```
@@ -347,7 +218,7 @@ The path to the project.js of the new project needs to be added to the example f
       make gen-buildfiles DEVICE=am243x
       ```
 
-##### Option 2: MCU+ SDK repository which is core for all the Sitara MCU and MPU devices is used
+#### Option 2: MCU+ SDK repository which is core for all the Sitara MCU and MPU devices is used
    ```bash
    make gen-buildfiles DEVICE={device} GEN_BUILDFILES_TARGET=development
    ```
@@ -356,7 +227,7 @@ The path to the project.js of the new project needs to be added to the example f
       make gen-buildfiles DEVICE=am243x GEN_BUILDFILES_TARGET=development
       ```
 
-#### Step 5 : Link or Copy source files to ccs workspace
+### Step 5 : Link or Copy source files to ccs workspace
 - In order to link source files to workspace add below in getComponentBuildProperty
    ```bash
    build_property.projecspecFileAction = "link"
@@ -366,10 +237,14 @@ The path to the project.js of the new project needs to be added to the example f
    build_property.projecspecFileAction = "copy"
    ```
 
-#### Step 6:  Import to CCS
+### Step 6:  Import to CCS
    - After step4, example.projectspec, makefile and the files mentioned in build_property.templates get generated
    - Now one can simply import the project by browsing to that folder in CCS, then build and test it.
 
-This project is currently not accepting contributions. Coming Soon!
+## Contributing to the OPEN PRU project
 
+We hope to start accepting contributions to the OPEN PRU project sometime soon. Reach out to us on [TI's E2E forums](https://e2e.ti.com/) for updates!
 
+## Technical Support
+
+Reach out to us with questions on [TI's E2E forums](https://e2e.ti.com/). Please note that support may be limited for OPEN PRU projects in the examples/ folder.

--- a/getting_started.md
+++ b/getting_started.md
@@ -1,0 +1,246 @@
+<div align="center">
+
+<img src="https://upload.wikimedia.org/wikipedia/commons/b/ba/TexasInstruments-Logo.svg" width="150"><br/>
+# Getting Started with OPEN PRU
+
+[Supported HOST environments](#supported-host-environments) | [Which core will initialize the PRU?](#which-core-will-initialize-the-pru) | [Install dependencies (manual installation)](#install-dependencies-manual-installation) | [Install dependencies (script)](#install-dependencies-script) | [Generate buildfiles](#generate-buildfiles)
+
+</div>
+
+## Introduction
+
+This page discusses how to:
+
+1. Install the associated SDK and tools for your development platform (Windows or Linux). Install dependencies manually, or use the pru_dependencies script (AM243x, AM64x only)
+
+2. Generate project buildfiles
+
+After the OPEN PRU repository has been set up, refer back to the [README](./README.md) for build steps.
+
+## Supported HOST environments
+
+- Validated on Windows 10 64bit. Higher versions may work
+- Validated on Ubuntu 18.04 64bit & Ubuntu 22.04 64bit. Higher versions may work
+
+## Which core will initialize the PRU?
+
+In your final design, the PRU cores must be initialized by another processor core. Depending on the processor, PRU cores can be initialized and controlled by cores running RTOS, bare metal, or Linux.
+
+TI supports initializing the PRU from an RTOS/bare metal core on these processors:
+- AM243x (R5F)
+- AM261x (R5F)
+- AM263x (R5F)
+- AM263px (R5F)
+- AM64x (R5F)
+
+TI supports initializing the PRU from Linux on these processors:
+- AM62x (A53)
+- AM64x (A53)
+
+TI supports RTOS & bare metal development through the MCU+ SDK, and Linux development through the Linux SDK.
+
+## Install dependencies (manual installation)
+
+AM243x & AM64x customers who will use the MCU+ SDK alongside PRU can install dependencies with the pru_dependencies script if they prefer. For those steps, refer to [Install dependencies (script)](#install-dependencies-script).
+
+**Note:** In general, software dependencies should all be installed under the same folder. So Windows developers would put all software tools under C:\ti, and Linux developers would put all software tools under ${HOME}/ti.
+
+If you will initialize the PRU cores from an RTOS or bare metal core, follow the steps in [Windows or Linux: Install the MCU+ SDK & tools](#windows-or-linux-install-the-mcu-sdk--tools).
+
+If you will initialize the PRU cores from a Linux core, follow the steps in [Linux: Install the Linux SDK & tools](#linux-install-the-linux-sdk--tools).
+
+### Windows or Linux: Install the MCU+ SDK & tools
+
+The MCU+ SDK is only a dependency when building OPEN PRU projects that include code for an MCU+ core.
+
+#### Install the MCU+ SDK
+
+Users can either install the prebuilt MCU+ SDK, or clone the MCU+ SDK repository:
+
+1. Download the prebuilt MCU+ SDK. The prebuilt SDK takes up less space on the computer, since it is packaged specifically for a single device.
+
+Please use the links below to download the installers:
+   - [AM243x MCU+ SDK](https://www.ti.com/tool/download/MCU-PLUS-SDK-AM243X)
+   - [AM261x MCU+ SDK](https://www.ti.com/tool/download/MCU-PLUS-SDK-AM261X)
+   - [AM263x MCU+ SDK](https://www.ti.com/tool/download/MCU-PLUS-SDK-AM263X)
+   - [AM263Px MCU+ SDK](https://www.ti.com/tool/download/MCU-PLUS-SDK-AM263PX)
+   - [AM64x MCU+ SDK](https://www.ti.com/tool/download/MCU-PLUS-SDK-AM64X)
+
+2. Clone the [MCU+ SDK repository](https://github.com/TexasInstruments/mcupsdk-core). Follow the mcupsdk-core README.md file for additional steps.
+
+#### Install the tools
+
+Users of the prebuilt MCU+ SDK, refer to the documentation associated with your specific SDK release. Users of the MCU+ SDK repository, refer to the documentation associated with the latest version of the MCU+ SDK.
+
+1. Install the versions of the tools that are listed in these pages:
+   - MCU+ SDK docs > Getting Started > Download, Install, and Setup SDK and Tools
+   - MCU+ SDK docs > Getting Started > Download, Install, and Setup CCS
+     - Developers using a Linux computer, make sure to follow the additional steps at "CCS Linux Host Support"
+   
+2. Download and install Node.js v12.18.4 LTS. Then install the node packages required for the open-pru:
+   - Go to the [NodeJS Website](https://nodejs.org/en/) and use the installer to
+     download and install v12.18.4 of node. Install in the default directory.
+   - After successful installation, run an `npm ci` inside the `open-pru` folder like so:
+      ```bash
+      $ cd open-pru/
+      $ npm ci
+      ```
+      - To specify a proxy server, use the --proxy option followed by the proxy server link, like this: `--proxy = <proxy server link>`
+
+After installing all dependencies, continue to section [Generate buildfiles](#generate-buildfiles).
+
+### Linux: Install the Linux SDK & tools
+
+The Linux SDK can only be installed on a Linux computer, not a Windows computer.
+
+#### Install the Linux SDK
+
+The Linux SDK is only a dependency if building code that will run on a Linux A53 core.
+
+Please use the links below to download the Linux SDK:
+   - [AM62x Linux SDK](https://www.ti.com/tool/download/PROCESSOR-SDK-LINUX-AM62X)
+   - [AM64x Linux SDK](https://www.ti.com/tool/download/PROCESSOR-SDK-LINUX-AM64X)
+
+#### Install the tools
+
+   1. Download and install Code Composer Studio v12.8 from [here](https://www.ti.com/tool/download/CCSTUDIO "Code Composer Studio")
+         - Please install these dependencies before installing CCS on a Linux computer. Use the command
+         ```bash
+         $ sudo apt -y install libc6:i386 libusb-0.1-4 libgconf-2-4 libncurses5 libpython2.7 libtinfo5 build-essential
+         ```
+
+   2. Download and install SysConfig 1.21.0 from [here](https://www.ti.com/tool/download/SYSCONFIG "SYSCONFIG 1.21.0")
+
+   3. Download and install the PRU compiler
+      - [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt)
+
+   4. Download and install GCC for Cortex A53 and R5F (if developing code to run on A53 or R5F)
+      - A53: [GNU-A](https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-elf.tar.xz)
+      - R5F: [GNU-RM](https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2)
+
+   5. Install Mono Runtime (required for creating bootloader images for application binaries)
+      - To install, use the command `sudo apt install mono-runtime`
+
+   6. Download and install Node.js v12.18.4 LTS
+      - Go to the [NodeJS Website](https://nodejs.org/en/) and use the installer to
+      download and install v12.18.4 of node. Install in the default directory.
+      - After successful installation, run an `npm ci` inside the `open-pru` folder like so:
+         ```bash
+         $ cd open-pru/
+         $ npm ci
+         ```
+      - To specify a proxy server, use the --proxy option followed by the proxy server link, like this: `--proxy = <proxy server link>`
+      This should install the node packages required for the open-pru.
+
+After installing all dependencies, continue to section [Generate buildfiles](#generate-buildfiles).
+
+## Install dependencies (script)
+
+The pru_dependencies scripts currently support installing MCU+ SDK and other dependencies on AM243x & AM64x. For all other devices, or for steps around installing the Linux SDK, please follow the steps at [Install dependencies (manual installation)](#install-dependencies-manual-installation).
+
+**Note:** In general, software dependencies should all be installed under the same folder. So Windows developers would put all software tools under C:\ti, and Linux developers would put all software tools under ${HOME}/ti.
+
+If the OPEN PRU repo is installed on a Windows machine, follow the steps in [Windows: Use script `pru_dependencies.bat` to install SDK & tools](#windows-use-script-pru_dependenciesbat-to-install-sdk--tools).
+
+If the OPEN PRU repo is installed on a Linux machine, follow the steps in [Linux: Use script `pru_dependencies.sh` to install SDK & tools](#linux-use-script-pru_dependenciessh-to-install-sdk--tools).
+
+### Windows: Use script `pru_dependencies.bat` to install SDK & tools
+
+**NOTES**
+
+   - If the script is executed from any folder but `C:\ti`, it will be copied to `C:\ti` after running it and a second terminal screen will be opened with the location of the script. Please re-run script in the new terminal screen
+   - If OpenSSL is needed to be installed, when prompted select option to install binaries to /bin folder of installed path instead of Windows system path
+   - If after installing the dependencies the script is executed to verify the installed, it will show the same missing dependencies. 
+   The used terminal must be closed and re-opened to get the updated state (or PC must be restarted). This is a Windows limitation
+
+#### Install the MCU+ SDK
+
+By default, the script checks for and installs MCU+ SDK 11.0. In order to use a different SDK version, edit the **version numbers** in pru_dependencies.bat to match the desired SDK version from:
+   - [AM243x MCU+ SDK](https://www.ti.com/tool/download/MCU-PLUS-SDK-AM243X)
+   - [AM64x MCU+ SDK](https://www.ti.com/tool/download/MCU-PLUS-SDK-AM64X)
+
+- For AM243x: run the command `pru_dependencies.bat -I --am243x_sdk`, `pru_dependencies.bat -i --am243x_sdk` or `pru_dependencies.bat install --am243x_sdk`
+
+- For AM64x: run the command `pru_dependencies.bat -I --am64xx_sdk`, `pru_dependencies.bat -i --am64xx_sdk` or `pru_dependencies.bat install --am64xx_sdk`
+
+Alternatively, the script can be used to clone the MCU+ SDK repository:
+
+- run the command `pru_dependencies.bat -I --clone_sdk`, `pru_dependencies.bat -i --clone_sdk` or `pru_dependencies.bat install --clone_sdk`
+
+#### Install the tools
+
+By default, the script checks for and installs the tool versions used with MCU+ SDK 11.0. If using a different SDK version, edit the **version numbers** in pru_dependencies.bat to match the versions listed in **the MCU+ SDK docs**, sections **Getting Started > Download, Install, and Setup SDK and Tools** and **Download, Install, and Setup CCS**.
+
+   1. It is recommended to verify the dependencies that are already installed. Run the command `pru_dependencies.bat -v`, `pru_dependencies.bat -V` or `pru_dependencies.bat verify`
+
+   2. To install the dependencies, run the command `pru_dependencies.bat -I [dependencies]`, `pru_dependencies.bat -i [dependencies]` or `pru_dependencies.bat install [dependencies]`
+
+   3. To get an assistance on how to use the script, run the command `pru_dependencies.bat -h` or `pru_dependencies.bat help`
+
+After installing all dependencies, continue to section [Generate buildfiles](#generate-buildfiles).
+
+### Linux: Use script `pru_dependencies.sh` to install SDK & tools
+
+**NOTES**
+
+- If the script is executed from any folder but `${HOME}/ti`, it will be copied to `${HOME}/ti` and executed from there automatically
+
+#### Install the MCU+ SDK
+
+By default, the script checks for and installs MCU+ SDK 11.0. In order to use a different SDK version, edit the **version numbers** in pru_dependencies.bat to match the desired SDK version from:
+   - [AM243x MCU+ SDK](https://www.ti.com/tool/download/MCU-PLUS-SDK-AM243X)
+   - [AM64x MCU+ SDK](https://www.ti.com/tool/download/MCU-PLUS-SDK-AM64X)
+
+- For AM243x: run the command `./pru_dependencies.sh -I --am243x_sdk`, `./pru_dependencies.sh -i --am243x_sdk` or `./pru_dependencies.sh install --am243x_sdk`
+
+- For AM64x: run the command `./pru_dependencies.sh -I --am64xx_sdk`, `./pru_dependencies.sh -i --am64xx_sdk` or `./pru_dependencies.sh install --am64xx_sdk`
+
+Alternatively, the script can be used to clone the MCU+ SDK repository:
+
+- run the command `./pru_dependencies.sh -I --clone_sdk`, `./pru_dependencies.sh -i --clone_sdk` or `./pru_dependencies.sh install --clone_sdk`
+
+#### Install the tools
+
+By default, the script checks for and installs the tool versions used with MCU+ SDK 11.0. If using a different SDK version, edit the **version numbers** in pru_dependencies.bat to match the versions listed in **the MCU+ SDK docs**, sections **Getting Started > Download, Install, and Setup SDK and Tools** and **Download, Install, and Setup CCS**.
+
+   1. It is recommended to verify the dependencies that are already installed. Run the command `./pru_dependencies.sh -v`, `./pru_dependencies.sh -V` or `./pru_dependencies.sh verify`
+
+   2. To install the dependencies, run the command `./pru_dependencies.sh -I [dependencies]`, `./pru_dependencies.sh -i [dependencies]` or `./pru_dependencies.sh install [dependencies]`
+
+   3. To get an assistance on how to use the script, run the command `./pru_dependencies.sh -h` or `./pru_dependencies.sh help`
+
+## Generate buildfiles
+
+These steps are used to generate makefiles and other build infrastructure for each OPEN PRU project.
+
+**NOTES**
+- Use `gmake` in Windows, and `make` in Linux. gmake is present in CCS. Add the path to the CCS gmake at `C:\ti\ccsxxxx\ccs\utils\bin` to your windows PATH.
+- Unless mentioned otherwise, all `make` commands are invoked from the root folder of the `open-pru` repository.
+   ```bash
+   cd open-pru/
+   ```
+- Current supported device names are am243x, am261x, am263x, am263px, am64x
+- Pass one of these values for `"DEVICE="`
+- You can also build components (examples, tests or libraries) in the `release` or `debug`
+  profiles. To do this pass one of these values for `"PROFILE="`
+---
+
+#### Option 1: If you installed the device-specific prebuilt MCU+ SDK:
+
+   ```bash
+   make gen-buildfiles DEVICE=am64x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH>
+   make gen-buildfiles DEVICE=am243x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH>
+   make gen-buildfiles DEVICE=am261x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH>
+   make gen-buildfiles DEVICE=am263px MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH>
+   make gen-buildfiles DEVICE=am263x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH>
+   ```
+
+#### Option 2: If you cloned the MCU+ SDK repository:
+
+   ```bash
+   make gen-buildfiles DEVICE=am64x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH> GEN_BUILDFILES_TARGET=development 
+   make gen-buildfiles DEVICE=am243x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH> GEN_BUILDFILES_TARGET=development
+   make gen-buildfiles DEVICE=am261x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH> GEN_BUILDFILES_TARGET=development
+   make gen-buildfiles DEVICE=am263px MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH> GEN_BUILDFILES_TARGET=development
+   make gen-buildfiles DEVICE=am263x MCU_PLUS_SDK_PATH=<MCU_PLUS_SDK_INSTALL_PATH> GEN_BUILDFILES_TARGET=development
+   ```


### PR DESCRIPTION
The README.md is too long, with too much information. If we want customers to refer back to this page regularly for build instructions, we should not make them scroll past the single-use "getting started" steps every single time.

1) Move getting started information to getting_started.md

2) restructure the getting started information:
2a) discuss MCU+ SDK vs Linux SDK, and split information by which SDK is used
2b) split "install dependencies" into 2 sections: manual installation, and
    using the install script
2c) add links from section to section to make it less likely that customers
    will skip over an important step on accident
2d) Generate buildfiles explaination added

3) Restructure README.md

Future work: after the PRU Academy goes live
1) Add links to the PRU Academy throughout the README.md
2) Remove section "Steps to add a new OPEN PRU project", as this will be
   completely covered in the PRU Academy Getting Started Labs. This will
   cut the README file down to a managable length for customers.