### PR TITLE
WIP: Rework PRU Makefiles

### DIFF
--- a/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/rtupru0_load_bin.h 
 		-$(RM) rtupru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/rtupru0_load_bin.h 
 		-$(RM) rtupru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/rtupru1_load_bin.h 
 		-$(RM) rtupru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/rtupru1_load_bin.h 
 		-$(RM) rtupru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/txpru0_load_bin.h 
 		-$(RM) txpru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/txpru0_load_bin.h 
 		-$(RM) txpru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/txpru1_load_bin.h 
 		-$(RM) txpru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-evm/txpru1_load_bin.h 
 		-$(RM) txpru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/rtupru0_load_bin.h 
 		-$(RM) rtupru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h empty_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/rtupru0_load_bin.h 
 		-$(RM) rtupru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/rtupru1_load_bin.h 
 		-$(RM) rtupru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/rtupru1_load_bin.h 
 		-$(RM) rtupru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/txpru0_load_bin.h 
 		-$(RM) txpru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/txpru0_load_bin.h 
 		-$(RM) txpru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/txpru1_load_bin.h 
 		-$(RM) txpru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM243X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h empty_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am243x-lp/txpru1_load_bin.h 
 		-$(RM) txpru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am261x-lp/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am261x-lp/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am261x-lp/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am261x-lp/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am261x-som/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am261x-som/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am261x-som_icss_m0_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am261x-som/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am261x-som/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am261x-som_icss_m0_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM261X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263px-cc/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263px-cc/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263px-cc/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263px-cc/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263px-lp/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263px-lp/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263px-lp/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263PX  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263px-lp/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263x-cc/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263x-cc/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263x-cc/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263x-cc/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263x-lp/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263x-lp/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263x-lp/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM263X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am263x-lp/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU0 -DSLICE0 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h empty_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/pru0_load_bin.h 
 		-$(RM) pru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/pru1_load_bin.h 
 		-$(RM) pru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DPRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/rtupru0_load_bin.h 
 		-$(RM) rtupru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h empty_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/rtupru0_load_bin.h 
 		-$(RM) rtupru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/rtupru1_load_bin.h 
 		-$(RM) rtupru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/rtupru1_load_bin.h 
 		-$(RM) rtupru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DRTU_PRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/txpru0_load_bin.h 
 		-$(RM) txpru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/txpru0_load_bin.h 
 		-$(RM) txpru0_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU0 -DSLICE0 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,6 +1,3 @@
-################################################################################
-# Automatically-generated file. Do not edit!
-################################################################################
 #   Required input arguments :
 #   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -8,54 +8,30 @@ CMD_SRCS += \
 ASM_SRCS += \
 	main.asm \
 
-OBJS += \
-	main.obj \
-
-ASM_DEPS += \
-	main.d \
-
-OBJDIR := .
-
-SYSCFG_DIR := ./syscfg
-
-FILES_PATH_common = \
-	.. \
-	../../.. \
-	. \
-
-FILES_PATH := $(FILES_PATH_common)
-
-vpath %.asm $(FILES_PATH)
-vpath %.obj $(OBJDIR)
-vpath %.cmd $(FILES_PATH)
-
 OUTPUT_NAME := empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
-TARGET := $(OUTPUT_NAME).out
-MAP := $(OUTPUT_NAME).map
-XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
+XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-# Add inputs and outputs from these tool invocations to the build variables
-EXE_OUTPUTS += \
-empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out \
-
-EXE_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out" \
-
-BIN_OUTPUTS += \
-empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.hex \
-
-BIN_OUTPUTS__QUOTED += \
-"empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.hex" \
+OBJ_DIR := $(GEN_DIR)
+SYSCFG_DIR := ./syscfg
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(OBJ_DIR)
+OBJS += $(GEN_DIR)/main.obj
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJDIR)/%.obj %.obj: %.asm
+$(OBJ_DIR)/%.obj %.obj: %.asm
+	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) -ppd -ppa $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -70,9 +46,7 @@ $(TARGET): $(OBJS) $(CMD_SRCS)
 
 # To clean generated files
 clean:
-	-$(RM) $(BIN_OUTPUTS__QUOTED)$(EXE_OUTPUTS__QUOTED)
-	-$(RM) $(OBJS)
-	-$(RM) $(ASM_DEPS)
+	-$(RMDIR) $(GEN_DIR)
 	-@echo 'Finished clean'
 	-@echo ' '
 

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,10 @@ vpath %.asm $(FILES_PATH)
 vpath %.obj $(OBJDIR)
 vpath %.cmd $(FILES_PATH)
 
+OUTPUT_NAME := empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
+TARGET := $(OUTPUT_NAME).out
+MAP := $(OUTPUT_NAME).map
+XML_LINK_INFO := $(OUTPUT_NAME)_linkInfo.xml
 
 # Add inputs and outputs from these tool invocations to the build variables
 EXE_OUTPUTS += \
@@ -45,7 +49,7 @@ BIN_OUTPUTS__QUOTED += \
 
 # All Target
 all: $(OBJS) $(CMD_SRCS)
-	@$(MAKE) --no-print-directory -Onone "empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out"
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
 $(OBJDIR)/%.obj %.obj: %.asm
@@ -56,10 +60,10 @@ $(OBJDIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out: $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m"empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.map" --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info="empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt_linkInfo.xml" --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o "empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^
 	@echo 'Finished building target: "$@"'
 	@echo ' '
 	@$(MAKE) --no-print-directory post-build
@@ -73,7 +77,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h $(TARGET)
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/txpru1_load_bin.h 
 		-$(RM) txpru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -4,7 +4,6 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
-CG_TOOL_ROOT := $(CGT_TI_PRU_PATH)
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -54,7 +53,7 @@ all: $(OBJS) $(CMD_SRCS)
 $(OBJDIR)/%.obj %.obj: %.asm
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
-	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CG_TOOL_ROOT}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
+	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM64X --include_path="${CGT_TI_PRU_PATH}/include" --include_path="${MCU_PLUS_SDK_PATH}/source" --include_path="${OPEN_PRU_PATH}/source" --include_path="${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common"  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little --preproc_with_compile --preproc_dependency="$(basename $(<F)).d_raw" $^
 	@echo 'Finished building: "$^"'
 	@echo ' '
 
@@ -76,7 +75,7 @@ clean:
 	-@echo ' '
 
 post-build:
-		-$(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out
+		-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out
 		-$(CAT)  ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/examples/empty/firmware/am64x-evm/txpru1_load_bin.h 
 		-$(RM) txpru1_load_bin.h
 	-@echo ' '

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,33 +1,35 @@
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
 
-# Add inputs and outputs from these tool invocations to the build variables
-CMD_SRCS += \
-	linker.cmd \
-
-ASM_SRCS += \
-	main.asm \
-
+# Define build outputs
 OUTPUT_NAME := empty_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
 GEN_DIR := generated
+
+# Create an object file for each assembly and C source file.
+# Add an entry for every *.asm and *.c source file like this:
+# OBJECTS := $(GEN_DIR)/asm_filename.obj $(GEN_DIR)/c_filename.obj
+OBJECTS := $(GEN_DIR)/main.obj
+
+# Linker command file
+CMD_SRCS := linker.cmd
+
 TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
 MAP := $(GEN_DIR)/$(OUTPUT_NAME).map
 XML_LINK_INFO := $(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml
 
-OBJ_DIR := $(GEN_DIR)
-SYSCFG_DIR := ./syscfg
 FILES_PATH := .. ../../.. .
 vpath %.asm $(FILES_PATH)
 vpath %.cmd $(FILES_PATH)
-vpath %.obj $(OBJ_DIR)
-OBJS += $(GEN_DIR)/main.obj
+vpath %.obj $(GEN_DIR)
+
+SYSCFG_DIR := $(GEN_DIR)/syscfg
 
 # All Target
-all: $(OBJS) $(CMD_SRCS)
+all: $(OBJECTS) $(CMD_SRCS)
 	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
 
 # Each subdirectory must supply rules for building sources it contributes
-$(OBJ_DIR)/%.obj %.obj: %.asm
+$(GEN_DIR)/%.obj %.obj: %.asm
 	@mkdir -p $(GEN_DIR)
 	@echo 'Building file: "$^"'
 	@echo 'Invoking: PRU Compiler'
@@ -36,7 +38,7 @@ $(OBJ_DIR)/%.obj %.obj: %.asm
 	@echo ' '
 
 # Tool invocations
-$(TARGET): $(OBJS) $(CMD_SRCS)
+$(TARGET): $(OBJECTS) $(CMD_SRCS)
 	@echo 'Building target: "$@"'
 	@echo 'Invoking: PRU Linker'
 	"$(CGT_TI_PRU_PATH)/bin/clpru" -DTX_PRU1 -DSLICE1 -v4 --define=SOC_AM64X  --define=_DEBUG_=1 -g --diag_warning=225 --diag_wrap=off --display_error_number --endian=little -z -m$(MAP) --disable_auto_rts   --diag_wrap=off --display_error_number --warn_sections --xml_link_info=$(XML_LINK_INFO) --disable_auto_rts --entry_point=main --diag_suppress=10063-D  --rom_model -o $(TARGET) $^

--- a/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,9 +1,5 @@
-#   Required input arguments :
-#   CCS_PROJECT_DEBUG=${CWD}   Use this input argument to include files from external paths
-
 export OPEN_PRU_PATH?=$(abspath ../../../../../..)
 include $(OPEN_PRU_PATH)/imports.mak
-SYSCFG_DIR := $(CCS_PROJECT_DEBUG)/syscfg
 
 # Add inputs and outputs from these tool invocations to the build variables
 CMD_SRCS += \
@@ -19,6 +15,8 @@ ASM_DEPS += \
 	main.d \
 
 OBJDIR := .
+
+SYSCFG_DIR := ./syscfg
 
 FILES_PATH_common = \
 	.. \


### PR DESCRIPTION
### **User description**
1) simplify makefiles to:
1a) make the makefiles more portable from project to project
1b) make the makefiles easier to read and understand
1c) make the makefiles easier to modify by hand
2) add support for compiling C firmware
3) Fix misc bugs

Start with empty project. Once we align on a design, modify all projects


___

### **PR Type**
Enhancement


___

### **Description**
• Comprehensive rework of PRU makefiles across all firmware targets to improve maintainability and portability
• Simplified makefile structure by removing verbose variable declarations and auto-generated comments
• Introduced standardized `GEN_DIR` and `OUTPUT_NAME` variables for better organization of build outputs in a `generated` directory
• Replaced hardcoded output filenames with parameterized variables (`TARGET`, `MAP`, `XML_LINK_INFO`)
• Updated compiler flags to use new directory structure with `--asm_directory`, `--obj_directory`, and `--pp_directory`
• Applied consistent changes across all supported platforms (AM243X, AM64X, AM261X, AM263X, AM263PX) and PRU cores (PRU0/1, RTU0/1, TX0/1)
• Enhanced makefile readability and ease of modification for future projects


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Makefiles"] --> B["Remove verbose declarations"]
  B --> C["Add GEN_DIR variable"]
  C --> D["Parameterize output files"]
  D --> E["Update compiler flags"]
  E --> F["Simplified Makefiles"]
  F --> G["Better portability"]
  F --> H["Easier maintenance"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>30 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU RTU0 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-951f3e86c27f9680397e9ff4c86db33e2f25cba386952fabb1d0c121418efcd8">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU RTU1 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-bcab804794c619f1ae4cde2f75ad713b435201804a443c26cddf1ea39d5d6158">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU RTU0 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-d2c1200c1cdec304dfc4984b84d0703ee3ec1302d7c4da50949088a07d5364f9">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU RTU1 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-44da5039a9dc2dc312747c7a43a8864d2a11ea084ccebe2344eb54cf529c4975">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU RTU0 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-3c1cb61d6467b6729c30ced82e15b431a6e0465bbeb9e27a027517f436d303ce">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU RTU1 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-88d567d5e4547d3f2955068edc5002e22fde7a7b316dd405ae2f9ddd757d78f8">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU TX0 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-bb12a64b5826f524f2a492d4354c52828a53f3dedf984e50c9c0711402695da2">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU TX1 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-e16a6394e7074329ff106f7abe392f8086a7439490b0d435e9d82046e7d181e0">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU TX0 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-1aaf3b410ce44983673b9c05cc09cc242c8dfd88ac556c6be8623d364101b24f">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU TX1 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-e8cae2ea4d8f069b45cf1842d4db470d2814ae54d62e302308516fee1d5fdb39">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU TX0 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-bf2869b01c67b129ef1d884194db9ba7b59e1062624833d025f452f70750618a">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU TX1 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-81aa9c2de53be0802df0a851b44e1404142aa188b760e94c4b4f145f1908fb90">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU0 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-55bae3f3493e66e2f7c91c952fcd91485bcc7b2a5fdf49726d8e656b83d9a33c">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU1 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-fe441015160261e2138024f158d66911aa2163b7c747eeab0e4d4e9e5f65da44">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU0 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-0c5d995a29e23b1614baa4d7caadeea904899f63704f916034f259cc8414a48b">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU1 makefile structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/empty/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing verbose variable <br>declarations and auto-generated comments<br> • Introduced <code>GEN_DIR</code> variable <br>for organizing build outputs in a <code>generated</code> directory<br> • Replaced <br>hardcoded output filenames with parameterized <code>TARGET</code>, <code>MAP</code>, and <br><code>XML_LINK_INFO</code> variables<br> • Updated compiler flags to use new directory <br>structure and improved preprocessor handling


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-b48ff39d33ccf952867467921f17eb89c3bb55cff8a5bdf58286527515f77412">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM243X PRU0</code></dd></summary>
<hr>

examples/empty/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-4d6bf44bbcf85fe83d558a089cb3aed8ed09353519c9c0f94b91d8862f064d70">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM243X PRU1</code></dd></summary>
<hr>

examples/empty/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-7a24b71bff6c682504fc1de88aa9e7f63b6650b631ae7f41b22f2212f35dcab0">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM261X PRU0</code></dd></summary>
<hr>

examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-643e1fb220bdc86c5fc5793249a11bc2ba2698bddf9cb4afe9ab8050da94d5f5">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM261X PRU1</code></dd></summary>
<hr>

examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-7c171465a5e8f9957ecd37ef4cdfd6ff29e1fb6618140f7cc6cd2c0b782e8477">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM261X SOM PRU0</code></dd></summary>
<hr>

examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-4c9899d18b18038c6dbc3757742aff371a63ad45c9d9b5c98868d1600bf43fae">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM261X SOM PRU1</code></dd></summary>
<hr>

examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-38e8d1755b4af988382bbe06002ae545685800aac48d9156f9d93e77df30e8f6">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM263PX CC PRU0</code></dd></summary>
<hr>

examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-b7b3035ba74055f86453964ec28a6c378420a43a02bc0653bd777c6285fcbf70">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM263PX CC PRU1</code></dd></summary>
<hr>

examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-e35e5f970e7fe187cbb307c1ae70af9e2e4bd588bb2df2a32955544f62f746b1">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM263PX LP PRU0</code></dd></summary>
<hr>

examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-f4d67824475c5a6d86f134bab44654827d9a0946f1e0945e6b434b329d9bac09">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM263PX LP PRU1</code></dd></summary>
<hr>

examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-f83c8c1bf1deca0f4a2e7fa365776350faf6c1b30484b814c06630db6dd3fdbb">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM263X CC PRU0</code></dd></summary>
<hr>

examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-332eef165a90d5897f4f095f3a333ecb37d28b0225412e594f425bd11ec03062">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM263X CC PRU1</code></dd></summary>
<hr>

examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-cab98169983295f293fa657af7fbc16555cd703afba53d322618c073f152db35">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM263X LP PRU0</code></dd></summary>
<hr>

examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-6b553f5bf67baaed37c7c03c632041d4e93d1409045d03bcffd8134226a30c29">+24/-50</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Simplify and modernize PRU makefile structure for AM263X LP PRU1</code></dd></summary>
<hr>

examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile

• Simplified makefile structure by removing auto-generated comments <br>and CCS-specific variables<br> • Introduced <code>OUTPUT_NAME</code> and <code>GEN_DIR</code> <br>variables for better organization of build outputs<br> • Replaced <br>hardcoded file paths with variable-based paths using <code>$(TARGET)</code>, <br><code>$(MAP)</code>, and <code>$(XML_LINK_INFO)</code><br> • Updated compiler flags to use new <br>directory structure with <code>--asm_directory</code>, <code>--obj_directory</code>, and <br><code>--pp_directory</code>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/60/files#diff-f86df50936e29097f92da778e57ba51500e0fa59f10bc575d0830868b7e896dc">+24/-50</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

