### PR TITLE
am243x: spi_loopback : fix pru firmware build due to missing include …

### DIFF
--- a/examples/makefile
+++ b/examples/makefile
@@ -2,8 +2,7 @@ include ../imports.mak
 
 # which projects will be built?
 SUBDIRS := custom_frequency_generator logic_scope fft/split_radix_fft_4k_single_core fft/split_radix_fft_post_processing
-SUBDIRS_MCUPLUS := empty pru_emif
-#TODO: add spi_loopback to SUBDIRS_MCUPLUS after make is fixed
+SUBDIRS_MCUPLUS := empty pru_emif spi_loopback
 SUBDIRS_LINUX :=
 
 ifeq ($(BUILD_MCUPLUS),y)

--- a/examples/spi_loopback/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/examples/spi_loopback/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -33,7 +33,8 @@ COMMAND_FILES := linker.cmd
 # Include paths
 INCLUDE := \
 	--include_path=$(CGT_TI_PRU_PATH)/include \
-	--include_path=$(OPEN_PRU_PATH)/source
+	--include_path=$(OPEN_PRU_PATH)/source \
+	--include_path=../../
 ifeq ($(BUILD_MCUPLUS),y)
 INCLUDE += \
 	--include_path=$(MCU_PLUS_SDK_PATH)/source \

--- a/examples/spi_loopback/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/examples/spi_loopback/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -33,7 +33,8 @@ COMMAND_FILES := linker.cmd
 # Include paths
 INCLUDE := \
 	--include_path=$(CGT_TI_PRU_PATH)/include \
-	--include_path=$(OPEN_PRU_PATH)/source
+	--include_path=$(OPEN_PRU_PATH)/source \
+	--include_path=../../
 ifeq ($(BUILD_MCUPLUS),y)
 INCLUDE += \
 	--include_path=$(MCU_PLUS_SDK_PATH)/source \


### PR DESCRIPTION
### **User description**
…path

spi_master_macros.inc and spi_slave_macros.inc are couple of level above in folder structure


___

### **PR Type**
Bug fix


___

### **Description**
- Fix PRU firmware build by adding missing include path

- Enable spi_loopback in top-level makefile


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build Error"] --> B["Add Include Path"]
  B --> C["PRU Firmware Builds"]
  D["Commented Out"] --> E["Enable in Makefile"]
  E --> F["spi_loopback Available"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Enable spi_loopback in build system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/makefile

<ul><li>Remove TODO comment about spi_loopback build fix<br> <li> Add spi_loopback to SUBDIRS_MCUPLUS for building</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/80/files#diff-f34d31e28c1a892105c312c82c1826de50520c77e494d81be38d820b11741de5">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Add missing include path for PRU0 firmware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/spi_loopback/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile

<ul><li>Add include path <code>../../</code> to access parent directory files<br> <li> Fix missing spi_master_macros.inc and spi_slave_macros.inc includes</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/80/files#diff-8d8ff6bc9f4d6e5d2b2496d2f3fb260146e613b741c07e515713e2d9e29dbbab">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>makefile</strong><dd><code>Add missing include path for PRU1 firmware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/spi_loopback/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile

<ul><li>Add include path <code>../../</code> to access parent directory files<br> <li> Fix missing spi_master_macros.inc and spi_slave_macros.inc includes</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/80/files#diff-5282d627b8beaf44d3d57b49d7c3ef96fa5042cad0a54f10c6ff91320ff65987">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

