### PR TITLE
Add PRU Getting Started Labs

### DIFF
--- a/academy/getting_started_labs/assembly_code/main.asm
+++ b/academy/getting_started_labs/assembly_code/main.asm
@@ -1,0 +1,65 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright (C) 2018-2025 Texas Instruments Incorporated - http://www.ti.com/
+
+;******************************************************************************
+;   File:     main.asm
+;
+;   Brief:    pru_add: Add 2 numbers in an infinite loop
+;******************************************************************************
+
+;******************************************************************************
+; Build Configuration
+;******************************************************************************
+
+; Required for building .out with assembly file
+    .retain
+    .retainrefs
+
+;*****************************************************************************
+; Definitions
+; Brief: Define x & y values. Define storage registers
+;*****************************************************************************
+
+; TODO: define y
+x	        .set	1
+
+; TODO: define y_register and z_register
+x_register	.set	r20
+
+; .sect ".text:main" places all code below the .sect directive into the .text
+; section, grouped into a subsection named "main"
+    .sect       ".text:main"
+    .clink
+    .global     main
+
+;*****************************************************************************
+; Main
+;*****************************************************************************
+main:
+
+;*****************************************************************************
+; Initialization Section
+; Brief: Clear registers and configure system
+;*****************************************************************************
+init:
+
+;----------------------------------------------------------------------------
+;   Clear the register space
+;   Before begining with the application, make sure registers R0 - R29 are set
+;   to 0. R30 & R31 are special, dedicated for output & input respectively
+;----------------------------------------------------------------------------
+    ; TODO: use zero to clear 30 four-byte registers, starting with R0
+    ; Give the starting address and number of bytes to clear.
+
+while_true:
+
+    ; TODO: load y value into y_register
+    ldi		x_register, x	; load x value into register r20
+
+    ; TODO: add x_register and y_register. Store the result in z_register
+
+    ; jump to continue refreshing z_register value
+    jmp		while_true
+
+    ; the jump prevents us from getting to halt
+    halt			; end of program

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_RTU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x RTU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_RTU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x RTU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x TX_PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x TX_PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_RTU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x RTU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_RTU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x RTU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x TX_PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM243x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM243x TX_PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM261x_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM261x PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM261x_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM261x PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM261x_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM261x PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-som_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM261x_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM261x PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-som_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM263px_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM263px PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-cc_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM263px_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM263px PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-cc_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM263px_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM263px PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM263px_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM263px PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_CC"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_CC"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM263x_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM263x PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-cc_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_CC"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_CC"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM263x_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM263x PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-cc_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_LAUNCHPAD"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM263x_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM263x PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_LAUNCHPAD"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,43 @@
+/*
+ * AM263x_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM263x PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM64x_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM64x PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM64x_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM64x PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM64x_RTU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM64x RTU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM64x_RTU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM64x RTU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM64x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM64x TX_PRU0 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,52 @@
+/*
+ * AM64x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking assembly programs built with the TI-PRU-CGT
+ * on AM64x TX_PRU1 cores
+ */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/firmware/main.asm
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/main.asm
@@ -1,0 +1,71 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright (C) 2018-2025 Texas Instruments Incorporated - http://www.ti.com/
+
+;******************************************************************************
+;   File:     main.asm
+;
+;   Brief:    pru_add: Add 2 numbers in an infinite loop
+;******************************************************************************
+
+;******************************************************************************
+; Build Configuration
+;******************************************************************************
+
+; Required for building .out with assembly file
+    .retain
+    .retainrefs
+
+;*****************************************************************************
+; Definitions
+; Brief: Define x & y values. Define storage registers
+;*****************************************************************************
+
+; TODO: define y
+x	        .set	1
+y	        .set	2
+
+; TODO: define y_register and z_register
+x_register	.set	r20
+y_register	.set	r21
+z_register	.set	r22
+
+; .sect ".text:main" places all code below the .sect directive into the .text
+; section, grouped into a subsection named "main"
+    .sect       ".text:main"
+    .clink
+    .global     main
+
+;*****************************************************************************
+; Main
+;*****************************************************************************
+main:
+
+;*****************************************************************************
+; Initialization Section
+; Brief: Clear registers and configure system
+;*****************************************************************************
+init:
+
+;----------------------------------------------------------------------------
+;   Clear the register space
+;   Before begining with the application, make sure registers R0 - R29 are set
+;   to 0. R30 & R31 are special, dedicated for output & input respectively
+;----------------------------------------------------------------------------
+    ; TODO: use zero to clear 30 four-byte registers, starting with R0
+    ; Give the starting address and number of bytes to clear.
+    zero    &R0, 120
+
+while_true:
+
+    ; TODO: load y value into y_register
+    ldi		x_register, x	; load x value into register r20
+    ldi		y_register, y	; load y value into register r21
+
+    ; TODO: add x_register and y_register. Store the result in z_register
+    add		z_register, x_register, y_register
+
+    ; jump to continue refreshing z_register value
+    jmp		while_true
+
+    ; the jump prevents us from getting to halt
+    halt			; end of program

--- a/academy/getting_started_labs/assembly_code/solution/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/makefile
@@ -1,0 +1,165 @@
+include ../../../../imports.mak
+
+#######################
+# project information #
+#######################
+
+PROJECT_NAME := pru_add
+SUPPORTED_PROCESSORS := am243x am261x am263px am263x am64x
+# Does the PRU code have dependencies outside of the open-pru repo?
+PRU_DEPENDENCIES :=
+# Use NON_PRU_DEPENDENCIES to select which makefiles to call for non-PRU cores
+NON_PRU_DEPENDENCIES := mcuplus
+
+###################
+# Prebuild checks #
+###################
+BUILD_PROJECT := y
+DEVICE_NON_PRU :=
+
+# Only build project if $(DEVICE) is in $(SUPPORTED_PROCESSORS)
+ifeq (,$(findstring $(DEVICE),$(SUPPORTED_PROCESSORS)))
+BUILD_PROJECT := n
+MESSAGE := Project $(PROJECT_NAME) does not have a build option for $(DEVICE)
+endif
+
+# Only build project if PRU dependencies exist
+ifneq (,$(PRU_DEPENDENCIES))
+# MCU+ SDK dependency?
+ifeq (mcuplus,$(findstring mcuplus,$(PRU_DEPENDENCIES)))
+ifneq ($(BUILD_MCUPLUS),y)
+BUILD_PROJECT := n
+MESSAGE ?= Project $(PROJECT_NAME) depends on MCU+ SDK, but BUILD_MCUPLUS != y.
+endif
+endif
+# Additional PRU dependency checks go here. For example:
+#ifeq (dependency,$(findstring dependency,$(PRU_DEPENDENCIES)))
+#if (dependency check fails)
+#BUILD_PROJECT := n
+#MESSAGE ?= Project $(PROJECT_NAME) depends on dependency, but dependency does not exist.
+#endif
+#endif
+endif
+
+# Only build non-PRU code if the non-PRU code is enabled in imports.mak
+ifeq ($(BUILD_MCUPLUS),y)
+ifeq (mcuplus,$(findstring mcuplus,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_mcuplus
+endif
+endif
+ifeq ($(BUILD_LINUX),y)
+ifeq (linux,$(findstring linux,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_linux
+endif
+endif
+
+###########################
+# Make and clean commands #
+###########################
+
+ifeq ($(BUILD_PROJECT),y)
+# "make" or "make all" builds projects that match $(DEVICE) set in imports.mak
+all: ARGUMENTS_PRU = all
+all: ARGUMENTS_MCUPLUS = $(ARGUMENTS_PRU)
+all: MESSAGE = "Building getting_started_labs/assembly_code/$(PROJECT_NAME) for $(DEVICE)"
+all: pre_build_message $(DEVICE) $(DEVICE_NON_PRU)
+
+# "make clean" cleans projects that match $(DEVICE) set in imports.mak
+clean: ARGUMENTS_PRU = clean
+clean: ARGUMENTS_MCUPLUS = scrub
+clean: MESSAGE = "Cleaning getting_started_labs/assembly_code/$(PROJECT_NAME) for $(DEVICE)"
+clean: pre_build_message $(DEVICE) $(DEVICE_NON_PRU)
+
+else
+# if a prebuild check failed, print message and exit
+all clean: pre_build_message
+endif
+
+pre_build_message:
+	@echo $(MESSAGE)
+
+######################
+# Target definitions #
+######################
+
+# provide target definitions for each supported processor
+# PRU firmware should be built before any RTOS code that includes it
+am243x:
+# am243x-evm
+	$(MAKE) -C firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am243x-lp
+	$(MAKE) -C firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am243x_mcuplus:
+# am243x-evm
+	$(MAKE) -C mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am243x-lp
+	$(MAKE) -C mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am261x:
+# am261x-lp
+	$(MAKE) -C firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am261x-som
+	$(MAKE) -C firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am261x_mcuplus:
+# am261x-lp
+	$(MAKE) -C mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am261x-som
+	$(MAKE) -C mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am263px:
+# am263px-lp
+	$(MAKE) -C firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am263px-cc
+	$(MAKE) -C firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am263px_mcuplus:
+# am263px-lp
+	$(MAKE) -C mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am263px-cc
+	$(MAKE) -C mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am263x:
+# am263x-lp
+	$(MAKE) -C firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am263x-cc
+	$(MAKE) -C firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am263x_mcuplus:
+# am263x-lp
+	$(MAKE) -C mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am263x-cc
+	$(MAKE) -C mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am64x:
+# am64x-evm
+	$(MAKE) -C firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am64x_mcuplus:
+# am64x-evm
+	$(MAKE) -C mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+.PHONY: all clean pre_build_message $(DEVICE) $(DEVICE_NON_PRU) $(SUPPORTED_PROCESSORS)
+

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,253 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALV_beta" --package "ALV" --part "ALV" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.00"
+ * @versions {"data":"2021012919","timestamp":"2021012919","tool":"1.8.0+1785","templates":null}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+const mpu_armv76 = mpu_armv7.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x180;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0180;
+region1.memory_region[7].size               = 0x3E80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+mpu_armv76.$name             = "CONFIG_MPU_REGION5";
+mpu_armv76.baseAddr          = 0x80000000;
+mpu_armv76.size              = 31;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution = "UART0_TXD";

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALV"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am243x-evm_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM2434_ALV"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALV --package ALV
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,340 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part ALV --package ALV --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM243x_ALV_beta --context r5fss0-0 --part ALV --package ALV --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,113 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am243x-evm_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,249 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALX_beta" --package "ALX" --part "ALX" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"data":"2021040816","timestamp":"2021040816","tool":"1.8.1+1900","templates":null}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x180;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0180;
+region1.memory_region[7].size               = 0x3E80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "B10";
+debug_log.uartLog.UART.TXD.$suggestSolution = "B11";

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALX"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am243x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM2434_ALX"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALX --package ALX
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,340 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part ALX --package ALX --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM243x_ALX_beta --context r5fss0-0 --part ALX --package ALX --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,113 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am243x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,291 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM261x_ZFG" --part "AM2612" --package "ZFG" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2612" --package "NFBGA (ZFG)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                    = "CONFIG_PRU_ICSS0";
+pruicss1.instance                                                                 = "ICSSM1";
+pruicss1.AdditionalICSSSettings[0].$name                                          = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                               = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO0.$assign = "GPIO81";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO0.$used   = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO8.$used   = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "GPIO27";
+debug_log.uartLog.UART.TXD.$assign = "GPIO28";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x70150000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x70154000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].$suggestSolution                = "PRU-ICSS1";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO8.$suggestSolution = "GPIO44";

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am261x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM261x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am261x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM2612 --package ZFG
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.debug.lib
+                -lboard.am261x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.release.lib
+                -lboard.am261x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM261X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am261x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM2612 --package ZFG --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM261x_ZFG --context r5fss0-0 --part AM2612 --package ZFG --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am261x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,276 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM261x_ZCZ" --part "AM2611" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2611" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name = "CONFIG_PRU_ICSS0";
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "GPIO27";
+debug_log.uartLog.UART.TXD.$assign = "GPIO28";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x70150000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x70154000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am261x-som_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM261x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am261x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM2611 --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.debug.lib
+                -lboard.am261x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.release.lib
+                -lboard.am261x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM261X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am261x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM2611 --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM261x_ZCZ --context r5fss0-0 --part AM2611 --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am261x-som_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,289 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_S" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-S)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                 = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                       = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                            = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.rx    = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$used = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].$suggestSolution                = "PRU-ICSS";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263Px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263px-cc_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263Px"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263px"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263P4 --package ZCZ_S
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.debug.lib
+                -lboard.am263px.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.release.lib
+                -lboard.am263px.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/linker.cmd
@@ -1,0 +1,137 @@
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=16384
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=32768
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is enabled
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 256;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 256;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > OCRAM
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > OCRAM
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > OCRAM
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > OCRAM
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > OCRAM
+
+    /* Sections needed for C++ projects */
+    GROUP {
+        .ARM.exidx:  {} palign(8)   /* Needed for C++ exception handling */
+        .init_array: {} palign(8)   /* Contains function pointers called before main */
+        .fini_array: {} palign(8)   /* Contains function pointers called after main */
+    } > OCRAM
+
+    /* General purpose user shared memory, used in some examples */
+    .bss.user_shared_mem (NOLOAD) : {} > USER_SHM_MEM
+    /* this is used when Debug log's to shared memory are enabled, else this is not used */
+    .bss.log_shared_mem  (NOLOAD) : {} > LOG_SHM_MEM
+    /* this is used only when IPC RPMessage is enabled, else this is not used */
+    .bss.ipc_vring_mem   (NOLOAD) : {} > RTOS_NORTOS_IPC_SHM_MEM
+    /* this is used only when Secure IPC is enabled */
+    .bss.sipc_hsm_queue_mem   (NOLOAD) : {} > MAILBOX_HSM
+    .bss.sipc_r5f_queue_mem   (NOLOAD) : {} > MAILBOX_R5F
+}
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB  : ORIGIN = 0x00080000 , LENGTH = 0x00008000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    OCRAM     : ORIGIN = 0x70040000 , LENGTH = 0x40000
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60100000 , LENGTH = 0x80000
+
+
+    /* shared memories that are used by RTOS/NORTOS cores */
+    /* On R5F,
+     * - make sure there is a MPU entry which maps below regions as non-cache
+     */
+    USER_SHM_MEM            : ORIGIN = 0x701D0000, LENGTH = 0x00004000
+    LOG_SHM_MEM             : ORIGIN = 0x701D4000, LENGTH = 0x00004000
+    /* MSS mailbox memory is used as shared memory, we dont use bottom 32*12 bytes, since its used as SW queue by ipc_notify */
+    RTOS_NORTOS_IPC_SHM_MEM : ORIGIN = 0x72000000, LENGTH = 0x3E80
+    MAILBOX_HSM:    ORIGIN = 0x44000000 , LENGTH = 0x000003CE
+    MAILBOX_R5F:    ORIGIN = 0x44000400 , LENGTH = 0x000003CE
+    }

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263PX \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263px:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263P4 --package ZCZ_S --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263Px --context r5fss0-0 --part AM263P4 --package ZCZ_S --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263px-cc_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,289 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_C" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-C)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                 = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                       = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                            = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.rx    = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$used = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].$suggestSolution                = "PRU-ICSS";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263Px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263px-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263Px"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263px"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263P4 --package ZCZ_C
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.debug.lib
+                -lboard.am263px.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.release.lib
+                -lboard.am263px.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/linker.cmd
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/linker.cmd
@@ -1,0 +1,137 @@
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=16384
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=32768
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is enabled
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 256;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 256;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > OCRAM
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > OCRAM
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > OCRAM
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > OCRAM
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > OCRAM
+
+    /* Sections needed for C++ projects */
+    GROUP {
+        .ARM.exidx:  {} palign(8)   /* Needed for C++ exception handling */
+        .init_array: {} palign(8)   /* Contains function pointers called before main */
+        .fini_array: {} palign(8)   /* Contains function pointers called after main */
+    } > OCRAM
+
+    /* General purpose user shared memory, used in some examples */
+    .bss.user_shared_mem (NOLOAD) : {} > USER_SHM_MEM
+    /* this is used when Debug log's to shared memory are enabled, else this is not used */
+    .bss.log_shared_mem  (NOLOAD) : {} > LOG_SHM_MEM
+    /* this is used only when IPC RPMessage is enabled, else this is not used */
+    .bss.ipc_vring_mem   (NOLOAD) : {} > RTOS_NORTOS_IPC_SHM_MEM
+    /* this is used only when Secure IPC is enabled */
+    .bss.sipc_hsm_queue_mem   (NOLOAD) : {} > MAILBOX_HSM
+    .bss.sipc_r5f_queue_mem   (NOLOAD) : {} > MAILBOX_R5F
+}
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB  : ORIGIN = 0x00080000 , LENGTH = 0x00008000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    OCRAM     : ORIGIN = 0x70040000 , LENGTH = 0x40000
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60100000 , LENGTH = 0x80000
+
+
+    /* shared memories that are used by RTOS/NORTOS cores */
+    /* On R5F,
+     * - make sure there is a MPU entry which maps below regions as non-cache
+     */
+    USER_SHM_MEM            : ORIGIN = 0x701D0000, LENGTH = 0x00004000
+    LOG_SHM_MEM             : ORIGIN = 0x701D4000, LENGTH = 0x00004000
+    /* MSS mailbox memory is used as shared memory, we dont use bottom 32*12 bytes, since its used as SW queue by ipc_notify */
+    RTOS_NORTOS_IPC_SHM_MEM : ORIGIN = 0x72000000, LENGTH = 0x3E80
+    MAILBOX_HSM:    ORIGIN = 0x44000000 , LENGTH = 0x000003CE
+    MAILBOX_R5F:    ORIGIN = 0x44000400 , LENGTH = 0x000003CE
+    }

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263PX \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263px:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263P4 --package ZCZ_C --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263Px --context r5fss0-0 --part AM263P4 --package ZCZ_C --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263px-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,295 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @versions {"tool":"1.23.0+4000"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+const output_xbar     = scripting.addModule("/xbar/output_xbar/output_xbar", {}, false);
+const output_xbar1    = output_xbar.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                              = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                    = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                         = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.slewRate = "high";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.$used    = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+output_xbar1.$name                         = "CONFIG_OUTPUT_XBAR0";
+output_xbar1.xbarOutput                    = ["EPWM0_TRIPOUT"];
+output_xbar1.OUTPUTXBAR.$assign            = "OUTPUTXBAR0";
+output_xbar1.OUTPUTXBAR.OUTPUTXBAR.$assign = "QSPI_CSn1";
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.$suggestSolution                = "ICSSM";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2022 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263x-cc_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263x --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.debug.lib
+                -lboard.am263x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.release.lib
+                -lboard.am263x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263x --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263x_beta --context r5fss0-0 --part AM263x --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263x-cc_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,273 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.18.0+3266"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2022 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263x --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.debug.lib
+                -lboard.am263x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.release.lib
+                -lboard.am263x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263x --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263x_beta --context r5fss0-0 --part AM263x --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,253 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM64x" --package "ALV" --part "Default" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.17.0+3128"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+mpu_armv76.$name    = "CONFIG_MPU_REGION5";
+mpu_armv76.baseAddr = 0x80000000;
+mpu_armv76.size     = 31;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x80;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0080;
+region1.memory_region[7].size               = 0x3F80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution = "UART0_TXD";

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM64x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am64x-evm_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM64x"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am64x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am64x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part Default --package ALV
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am64x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am64x.r5f.ti-arm-clang.debug.lib
+                -lboard.am64x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am64x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am64x.r5f.ti-arm-clang.release.lib
+                -lboard.am64x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,341 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am64x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM64X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am64x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am64x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am64x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am64x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am64x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am64x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part Default --package ALV --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM64x --context r5fss0-0 --part Default --package ALV --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,114 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am64x-evm_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/pru_add.c
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/pru_add.c
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_drivers_open_close.h"
+#include "ti_board_open_close.h"
+#include <drivers/pruicss.h>
+
+#include <pru0_load_bin.h>
+#include <pru1_load_bin.h>
+#if defined(SOC_AM64X) || defined(SOC_AM243X)
+#include <rtupru0_load_bin.h>
+#include <rtupru1_load_bin.h>
+#include <txpru0_load_bin.h>
+#include <txpru1_load_bin.h>
+#endif
+
+
+
+/*
+ *  This is an example project to show R5F
+ *  loading PRU firmware.
+ */
+
+/** \brief Global Structure pointer holding PRUSS1 memory Map. */
+
+PRUICSS_Handle gPruIcss0Handle;
+
+
+void pru_io_pru_add_main(void *args)
+{
+     Drivers_open(); // check return status
+
+     int status;
+     status = Board_driversOpen();
+     DebugP_assert(SystemP_SUCCESS == status);
+
+     gPruIcss0Handle = PRUICSS_open(CONFIG_PRU_ICSS0);
+
+     status = PRUICSS_initMemory(gPruIcss0Handle, PRUICSS_DATARAM(PRUICSS_PRU0));
+     DebugP_assert(status != 0);
+
+     status = PRUICSS_initMemory(gPruIcss0Handle, PRUICSS_DATARAM(PRUICSS_PRU1));
+     DebugP_assert(status != 0);
+
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_PRU0, PRU0Firmware_0, sizeof(PRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_PRU1, PRU1Firmware_0, sizeof(PRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+
+     #if defined(SOC_AM64X) || defined(SOC_AM243X)
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_RTU_PRU0, RTUPRU0Firmware_0, sizeof(RTUPRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_RTU_PRU1, RTUPRU1Firmware_0, sizeof(RTUPRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_TX_PRU0, TXPRU0Firmware_0, sizeof(TXPRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_TX_PRU1, TXPRU1Firmware_0, sizeof(TXPRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     #endif
+
+     while (1)
+     {
+        ClockP_usleep(1);
+     }
+
+     Board_driversClose();
+     Drivers_close();
+}

--- a/academy/getting_started_labs/assembly_code/solution/readme.md
+++ b/academy/getting_started_labs/assembly_code/solution/readme.md
@@ -1,0 +1,41 @@
+# PRU Getting Started Labs - getting started with assembly
+
+## Introduction
+
+This example acts as a getting started point for PRU firmware development in assembly.
+
+# Supported Combinations
+
+ Parameter      | Value
+ ---------------|-----------
+ ICSSG          | ICSSG0 - PRU0, PRU1, RTU0, RTU1, TX_PRU0,TX_PRU1
+ ICSSM          | ICSSM0 - PRU0, PRU1
+                | ICSSM1 - PRU0, PRU1 (am261x only)
+ Toolchain      | pru-cgt
+ Board          | am64x-evm, am243x-evm, am243x-lp, am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp
+ Example folder | academy/getting_started_labs/assembly_code/solution/
+
+# Steps to Run the Example
+
+> Prerequisite: [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt) should be installed at: `C:/ti/`
+
+- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU, After this `main.asm`, `linker.cmd` files gets copied to ccs workspace of PRU project. The `main.asm` contains sample code to halt PRU program
+
+     - Build the PRU project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
+          - Build Flow: Once you click on build in PRU project, firmware header file which is generated in release or debug folder of ccs workspace, is moved to  `<open-pru/academy/getting_started_labs/assembly_code/solution/firmware/device/>`
+
+     - Build the R5F project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
+          - Firmware header file path is included in R5F project include options by default, Instructions in Firmware header file can be written into PRU IRAM memory using PRUICSS_loadFirmware API (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe))
+          - Build Flow: Once you click on build in R5F project, SysConfig files are generated, Finally the R5F project will be generated using both the generated SysConfig and PRU project binaries.
+
+     - Launch a CCS debug session and run the executable, (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_LAUNCH_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_LAUNCH_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_LAUNCH_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_LAUNCH_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_LAUNCH_PAGE.html))
+
+- **When using makefiles to build**:
+     - For steps on how to use makefiles, run `make help` from the root folder
+       of the open-pru repository.
+
+# Writing PRU code
+
+* You can modify this example to write your own firmware. For more information,
+  refer to
+  [Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).

--- a/academy/getting_started_labs/c_and_assembly/assm_add.asm
+++ b/academy/getting_started_labs/c_and_assembly/assm_add.asm
@@ -1,0 +1,36 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright (C) 2018-2025 Texas Instruments Incorporated - http://www.ti.com/
+
+;******************************************************************************
+; Build Configuration
+;******************************************************************************
+
+; Required for building .out with assembly file
+    .retain
+    .retainrefs
+
+; .sect ".text:assm_add" places all code below the .sect directive into the
+; .text section, grouped into a subsection named "assm_add"
+    .sect	".text:assm_add"
+    .clink
+    .global	assm_add
+
+;*****************************************************************************
+; uint32_t assm_add(uint32_t arg1, uint32_t arg2);
+;*****************************************************************************
+assm_add:
+
+;-----------------------------------------------------------------------------
+;   Function input arguments are stored in R14-R29.
+;   So the 32 bit value in arg1 is stored in R14, and the 32 bit value in
+;   arg2 is stored in R15. The return value is stored in R14.
+;
+;   For more details about how function arguments are stored in registers,
+;   reference the document "PRU Optimizing C/C+ Compiler User's Guide",
+;   section "Function Structure and Calling Conventions"
+;-----------------------------------------------------------------------------
+
+    ; TODO: add arg1 and arg2. Store the sum in the return register
+
+    ; return from function assm_add
+    JMP		r3.w2

--- a/academy/getting_started_labs/c_and_assembly/main.c
+++ b/academy/getting_started_labs/c_and_assembly/main.c
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (C) 2018-2025 Texas Instruments Incorporated - http://www.ti.com/
+ */
+
+#include <stdint.h>
+
+/* TODO: define c */
+/* a, b, and c are stored in a defined location in PRU memory */
+#define a  (*((volatile unsigned int *)0x110))
+#define b  (*((volatile unsigned int *)0x114))
+
+/* Declaration of the external assembly function */
+uint32_t assm_add(uint32_t arg1, uint32_t arg2);
+
+/*
+ * main.c
+ */
+void main(void)
+{
+	/* TODO: define y & z */
+	/* The compiler decides where to store x, y, and z */
+	uint32_t x = 1;
+
+	a = 1;
+	b = 2;
+
+	while(1) {
+		/*
+		 * TODO: use the assembly function to add x and y, then
+		 * store the sum in z
+		 */
+
+		/*
+		 * TODO: use the assembly function to add a and b, then
+		 * store the sum in memory location c
+		 */
+	}
+
+	/* This program will not reach __halt because of the while loop */
+	__halt();
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU0	: org = 0x0002A000 len = 0x0000004C	CREGISTER=10
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU1	: org = 0x0002A200 len = 0x0000004C	CREGISTER=10
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_RTU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU0	: org = 0x0002A100 len = 0x0000004C	CREGISTER=10
+	RTU0_CTRL	: org = 0x00023000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_RTU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU1	: org = 0x0002A300 len = 0x0000004C	CREGISTER=10
+	RTU1_CTRL	: org = 0x00023800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU0	: org = 0x0002A400 len = 0x0000004C	CREGISTER=10
+	TX_PRU0_CTRL	: org = 0x00025000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU1	: org = 0x0002A500 len = 0x0000004C	CREGISTER=10
+	TX_PRU1_CTRL	: org = 0x00025800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU0	: org = 0x0002A000 len = 0x0000004C	CREGISTER=10
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU1	: org = 0x0002A200 len = 0x0000004C	CREGISTER=10
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_RTU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU0	: org = 0x0002A100 len = 0x0000004C	CREGISTER=10
+	RTU0_CTRL	: org = 0x00023000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_RTU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU1	: org = 0x0002A300 len = 0x0000004C	CREGISTER=10
+	RTU1_CTRL	: org = 0x00023800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU0	: org = 0x0002A400 len = 0x0000004C	CREGISTER=10
+	TX_PRU0_CTRL	: org = 0x00025000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU1	: org = 0x0002A500 len = 0x0000004C	CREGISTER=10
+	TX_PRU1_CTRL	: org = 0x00025800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-som_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-som_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-cc_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-cc_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_CC"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_CC"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-cc_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_CC"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_CC"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-cc_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_LAUNCHPAD"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_LAUNCHPAD"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM64x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU0	: org = 0x0002A000 len = 0x0000004C	CREGISTER=10
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM64x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU1	: org = 0x0002A200 len = 0x0000004C	CREGISTER=10
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM64x_RTU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x RTU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU0	: org = 0x0002A100 len = 0x0000004C	CREGISTER=10
+	RTU0_CTRL	: org = 0x00023000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM64x_RTU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x RTU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU1	: org = 0x0002A300 len = 0x0000004C	CREGISTER=10
+	RTU1_CTRL	: org = 0x00023800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM64x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x TX_PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU0	: org = 0x0002A400 len = 0x0000004C	CREGISTER=10
+	TX_PRU0_CTRL	: org = 0x00025000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM64x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x TX_PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU1	: org = 0x0002A500 len = 0x0000004C	CREGISTER=10
+	TX_PRU1_CTRL	: org = 0x00025800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/assm_add.asm
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/assm_add.asm
@@ -1,0 +1,37 @@
+; SPDX-License-Identifier: BSD-3-Clause
+; Copyright (C) 2018-2025 Texas Instruments Incorporated - http://www.ti.com/
+
+;******************************************************************************
+; Build Configuration
+;******************************************************************************
+
+; Required for building .out with assembly file
+    .retain
+    .retainrefs
+
+; .sect ".text:assm_add" places all code below the .sect directive into the
+; .text section, grouped into a subsection named "assm_add"
+    .sect	".text:assm_add"
+    .clink
+    .global	assm_add
+
+;*****************************************************************************
+; uint32_t assm_add(uint32_t arg1, uint32_t arg2);
+;*****************************************************************************
+assm_add:
+
+;-----------------------------------------------------------------------------
+;   Function input arguments are stored in R14-R29.
+;   So the 32 bit value in arg1 is stored in R14, and the 32 bit value in
+;   arg2 is stored in R15. The return value is stored in R14.
+;
+;   For more details about how function arguments are stored in registers,
+;   reference the document "PRU Optimizing C/C+ Compiler User's Guide",
+;   section "Function Structure and Calling Conventions"
+;-----------------------------------------------------------------------------
+
+    ; TODO: add arg1 and arg2. Store the sum in the return register
+    ADD		R14, R14, R15
+
+    ; return from function assm_add
+    JMP		r3.w2

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/main.c
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/main.c
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (C) 2018-2025 Texas Instruments Incorporated - http://www.ti.com/
+ */
+
+#include <stdint.h>
+
+/* TODO: define c */
+/* a, b, and c are stored in a defined location in PRU memory */
+#define a  (*((volatile unsigned int *)0x110))
+#define b  (*((volatile unsigned int *)0x114))
+#define c  (*((volatile unsigned int *)0x118))
+
+/* Declaration of the external assembly function */
+uint32_t assm_add(uint32_t arg1, uint32_t arg2);
+
+/*
+ * main.c
+ */
+void main(void)
+{
+	/* TODO: define y & z */
+	/* The compiler decides where to store x, y, and z */
+	uint32_t x = 1;
+	uint32_t y = 2;
+	uint32_t z = 0;
+
+	a = 1;
+	b = 2;
+
+	while(1) {
+		/*
+		 * TODO: use the assembly function to add x and y, then
+		 * store the sum in z
+		 */
+		z = assm_add(x, y);
+
+		/*
+		 * TODO: use the assembly function to add a and b, then
+		 * store the sum in memory location c
+		 */
+		c = assm_add(a, b);
+	}
+
+	/* This program will not reach __halt because of the while loop */
+	__halt();
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/makefile
@@ -1,0 +1,165 @@
+include ../../../../imports.mak
+
+#######################
+# project information #
+#######################
+
+PROJECT_NAME := pru_add
+SUPPORTED_PROCESSORS := am243x am261x am263px am263x am64x
+# Does the PRU code have dependencies outside of the open-pru repo?
+PRU_DEPENDENCIES :=
+# Use NON_PRU_DEPENDENCIES to select which makefiles to call for non-PRU cores
+NON_PRU_DEPENDENCIES := mcuplus
+
+###################
+# Prebuild checks #
+###################
+BUILD_PROJECT := y
+DEVICE_NON_PRU :=
+
+# Only build project if $(DEVICE) is in $(SUPPORTED_PROCESSORS)
+ifeq (,$(findstring $(DEVICE),$(SUPPORTED_PROCESSORS)))
+BUILD_PROJECT := n
+MESSAGE := Project $(PROJECT_NAME) does not have a build option for $(DEVICE)
+endif
+
+# Only build project if PRU dependencies exist
+ifneq (,$(PRU_DEPENDENCIES))
+# MCU+ SDK dependency?
+ifeq (mcuplus,$(findstring mcuplus,$(PRU_DEPENDENCIES)))
+ifneq ($(BUILD_MCUPLUS),y)
+BUILD_PROJECT := n
+MESSAGE ?= Project $(PROJECT_NAME) depends on MCU+ SDK, but BUILD_MCUPLUS != y.
+endif
+endif
+# Additional PRU dependency checks go here. For example:
+#ifeq (dependency,$(findstring dependency,$(PRU_DEPENDENCIES)))
+#if (dependency check fails)
+#BUILD_PROJECT := n
+#MESSAGE ?= Project $(PROJECT_NAME) depends on dependency, but dependency does not exist.
+#endif
+#endif
+endif
+
+# Only build non-PRU code if the non-PRU code is enabled in imports.mak
+ifeq ($(BUILD_MCUPLUS),y)
+ifeq (mcuplus,$(findstring mcuplus,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_mcuplus
+endif
+endif
+ifeq ($(BUILD_LINUX),y)
+ifeq (linux,$(findstring linux,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_linux
+endif
+endif
+
+###########################
+# Make and clean commands #
+###########################
+
+ifeq ($(BUILD_PROJECT),y)
+# "make" or "make all" builds projects that match $(DEVICE) set in imports.mak
+all: ARGUMENTS_PRU = all
+all: ARGUMENTS_MCUPLUS = $(ARGUMENTS_PRU)
+all: MESSAGE = "Building getting_started_labs/c_and_assembly/$(PROJECT_NAME) for $(DEVICE)"
+all: pre_build_message $(DEVICE) $(DEVICE_NON_PRU)
+
+# "make clean" cleans projects that match $(DEVICE) set in imports.mak
+clean: ARGUMENTS_PRU = clean
+clean: ARGUMENTS_MCUPLUS = scrub
+clean: MESSAGE = "Cleaning getting_started_labs/c_and_assembly/$(PROJECT_NAME) for $(DEVICE)"
+clean: pre_build_message $(DEVICE) $(DEVICE_NON_PRU)
+
+else
+# if a prebuild check failed, print message and exit
+all clean: pre_build_message
+endif
+
+pre_build_message:
+	@echo $(MESSAGE)
+
+######################
+# Target definitions #
+######################
+
+# provide target definitions for each supported processor
+# PRU firmware should be built before any RTOS code that includes it
+am243x:
+# am243x-evm
+	$(MAKE) -C firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am243x-lp
+	$(MAKE) -C firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am243x_mcuplus:
+# am243x-evm
+	$(MAKE) -C mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am243x-lp
+	$(MAKE) -C mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am261x:
+# am261x-lp
+	$(MAKE) -C firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am261x-som
+	$(MAKE) -C firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am261x_mcuplus:
+# am261x-lp
+	$(MAKE) -C mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am261x-som
+	$(MAKE) -C mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am263px:
+# am263px-lp
+	$(MAKE) -C firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am263px-cc
+	$(MAKE) -C firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am263px_mcuplus:
+# am263px-lp
+	$(MAKE) -C mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am263px-cc
+	$(MAKE) -C mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am263x:
+# am263x-lp
+	$(MAKE) -C firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am263x-cc
+	$(MAKE) -C firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am263x_mcuplus:
+# am263x-lp
+	$(MAKE) -C mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am263x-cc
+	$(MAKE) -C mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am64x:
+# am64x-evm
+	$(MAKE) -C firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am64x_mcuplus:
+# am64x-evm
+	$(MAKE) -C mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+.PHONY: all clean pre_build_message $(DEVICE) $(DEVICE_NON_PRU) $(SUPPORTED_PROCESSORS)
+

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,253 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALV_beta" --package "ALV" --part "ALV" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.00"
+ * @versions {"data":"2021012919","timestamp":"2021012919","tool":"1.8.0+1785","templates":null}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+const mpu_armv76 = mpu_armv7.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x180;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0180;
+region1.memory_region[7].size               = 0x3E80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+mpu_armv76.$name             = "CONFIG_MPU_REGION5";
+mpu_armv76.baseAddr          = 0x80000000;
+mpu_armv76.size              = 31;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution = "UART0_TXD";

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALV"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am243x-evm_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM2434_ALV"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALV --package ALV
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,340 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part ALV --package ALV --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM243x_ALV_beta --context r5fss0-0 --part ALV --package ALV --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,113 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am243x-evm_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,249 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALX_beta" --package "ALX" --part "ALX" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"data":"2021040816","timestamp":"2021040816","tool":"1.8.1+1900","templates":null}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x180;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0180;
+region1.memory_region[7].size               = 0x3E80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "B10";
+debug_log.uartLog.UART.TXD.$suggestSolution = "B11";

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALX"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am243x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM2434_ALX"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALX --package ALX
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,340 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part ALX --package ALX --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM243x_ALX_beta --context r5fss0-0 --part ALX --package ALX --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,113 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am243x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,291 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM261x_ZFG" --part "AM2612" --package "ZFG" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2612" --package "NFBGA (ZFG)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                    = "CONFIG_PRU_ICSS0";
+pruicss1.instance                                                                 = "ICSSM1";
+pruicss1.AdditionalICSSSettings[0].$name                                          = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                               = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO0.$assign = "GPIO81";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO0.$used   = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO8.$used   = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "GPIO27";
+debug_log.uartLog.UART.TXD.$assign = "GPIO28";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x70150000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x70154000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].$suggestSolution                = "PRU-ICSS1";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO8.$suggestSolution = "GPIO44";

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am261x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM261x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am261x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM2612 --package ZFG
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.debug.lib
+                -lboard.am261x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.release.lib
+                -lboard.am261x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM261X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am261x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM2612 --package ZFG --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM261x_ZFG --context r5fss0-0 --part AM2612 --package ZFG --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am261x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,276 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM261x_ZCZ" --part "AM2611" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2611" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name = "CONFIG_PRU_ICSS0";
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "GPIO27";
+debug_log.uartLog.UART.TXD.$assign = "GPIO28";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x70150000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x70154000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am261x-som_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM261x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am261x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM2611 --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.debug.lib
+                -lboard.am261x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.release.lib
+                -lboard.am261x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM261X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am261x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM2611 --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM261x_ZCZ --context r5fss0-0 --part AM2611 --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am261x-som_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,289 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_S" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-S)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                 = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                       = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                            = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.rx    = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$used = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].$suggestSolution                = "PRU-ICSS";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263Px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263px-cc_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263Px"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263px"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263P4 --package ZCZ_S
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.debug.lib
+                -lboard.am263px.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.release.lib
+                -lboard.am263px.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/linker.cmd
@@ -1,0 +1,137 @@
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=16384
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=32768
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is enabled
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 256;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 256;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > OCRAM
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > OCRAM
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > OCRAM
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > OCRAM
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > OCRAM
+
+    /* Sections needed for C++ projects */
+    GROUP {
+        .ARM.exidx:  {} palign(8)   /* Needed for C++ exception handling */
+        .init_array: {} palign(8)   /* Contains function pointers called before main */
+        .fini_array: {} palign(8)   /* Contains function pointers called after main */
+    } > OCRAM
+
+    /* General purpose user shared memory, used in some examples */
+    .bss.user_shared_mem (NOLOAD) : {} > USER_SHM_MEM
+    /* this is used when Debug log's to shared memory are enabled, else this is not used */
+    .bss.log_shared_mem  (NOLOAD) : {} > LOG_SHM_MEM
+    /* this is used only when IPC RPMessage is enabled, else this is not used */
+    .bss.ipc_vring_mem   (NOLOAD) : {} > RTOS_NORTOS_IPC_SHM_MEM
+    /* this is used only when Secure IPC is enabled */
+    .bss.sipc_hsm_queue_mem   (NOLOAD) : {} > MAILBOX_HSM
+    .bss.sipc_r5f_queue_mem   (NOLOAD) : {} > MAILBOX_R5F
+}
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB  : ORIGIN = 0x00080000 , LENGTH = 0x00008000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    OCRAM     : ORIGIN = 0x70040000 , LENGTH = 0x40000
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60100000 , LENGTH = 0x80000
+
+
+    /* shared memories that are used by RTOS/NORTOS cores */
+    /* On R5F,
+     * - make sure there is a MPU entry which maps below regions as non-cache
+     */
+    USER_SHM_MEM            : ORIGIN = 0x701D0000, LENGTH = 0x00004000
+    LOG_SHM_MEM             : ORIGIN = 0x701D4000, LENGTH = 0x00004000
+    /* MSS mailbox memory is used as shared memory, we dont use bottom 32*12 bytes, since its used as SW queue by ipc_notify */
+    RTOS_NORTOS_IPC_SHM_MEM : ORIGIN = 0x72000000, LENGTH = 0x3E80
+    MAILBOX_HSM:    ORIGIN = 0x44000000 , LENGTH = 0x000003CE
+    MAILBOX_R5F:    ORIGIN = 0x44000400 , LENGTH = 0x000003CE
+    }

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263PX \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263px:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263P4 --package ZCZ_S --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263Px --context r5fss0-0 --part AM263P4 --package ZCZ_S --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263px-cc_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,289 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_C" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-C)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                 = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                       = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                            = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.rx    = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$used = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].$suggestSolution                = "PRU-ICSS";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263Px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263px-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263Px"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263px"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263P4 --package ZCZ_C
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.debug.lib
+                -lboard.am263px.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.release.lib
+                -lboard.am263px.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/linker.cmd
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/linker.cmd
@@ -1,0 +1,137 @@
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=16384
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=32768
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is enabled
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 256;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 256;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > OCRAM
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > OCRAM
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > OCRAM
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > OCRAM
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > OCRAM
+
+    /* Sections needed for C++ projects */
+    GROUP {
+        .ARM.exidx:  {} palign(8)   /* Needed for C++ exception handling */
+        .init_array: {} palign(8)   /* Contains function pointers called before main */
+        .fini_array: {} palign(8)   /* Contains function pointers called after main */
+    } > OCRAM
+
+    /* General purpose user shared memory, used in some examples */
+    .bss.user_shared_mem (NOLOAD) : {} > USER_SHM_MEM
+    /* this is used when Debug log's to shared memory are enabled, else this is not used */
+    .bss.log_shared_mem  (NOLOAD) : {} > LOG_SHM_MEM
+    /* this is used only when IPC RPMessage is enabled, else this is not used */
+    .bss.ipc_vring_mem   (NOLOAD) : {} > RTOS_NORTOS_IPC_SHM_MEM
+    /* this is used only when Secure IPC is enabled */
+    .bss.sipc_hsm_queue_mem   (NOLOAD) : {} > MAILBOX_HSM
+    .bss.sipc_r5f_queue_mem   (NOLOAD) : {} > MAILBOX_R5F
+}
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB  : ORIGIN = 0x00080000 , LENGTH = 0x00008000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    OCRAM     : ORIGIN = 0x70040000 , LENGTH = 0x40000
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60100000 , LENGTH = 0x80000
+
+
+    /* shared memories that are used by RTOS/NORTOS cores */
+    /* On R5F,
+     * - make sure there is a MPU entry which maps below regions as non-cache
+     */
+    USER_SHM_MEM            : ORIGIN = 0x701D0000, LENGTH = 0x00004000
+    LOG_SHM_MEM             : ORIGIN = 0x701D4000, LENGTH = 0x00004000
+    /* MSS mailbox memory is used as shared memory, we dont use bottom 32*12 bytes, since its used as SW queue by ipc_notify */
+    RTOS_NORTOS_IPC_SHM_MEM : ORIGIN = 0x72000000, LENGTH = 0x3E80
+    MAILBOX_HSM:    ORIGIN = 0x44000000 , LENGTH = 0x000003CE
+    MAILBOX_R5F:    ORIGIN = 0x44000400 , LENGTH = 0x000003CE
+    }

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263PX \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263px:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263P4 --package ZCZ_C --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263Px --context r5fss0-0 --part AM263P4 --package ZCZ_C --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263px-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,295 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @versions {"tool":"1.23.0+4000"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+const output_xbar     = scripting.addModule("/xbar/output_xbar/output_xbar", {}, false);
+const output_xbar1    = output_xbar.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                              = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                    = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                         = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.slewRate = "high";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.$used    = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+output_xbar1.$name                         = "CONFIG_OUTPUT_XBAR0";
+output_xbar1.xbarOutput                    = ["EPWM0_TRIPOUT"];
+output_xbar1.OUTPUTXBAR.$assign            = "OUTPUTXBAR0";
+output_xbar1.OUTPUTXBAR.OUTPUTXBAR.$assign = "QSPI_CSn1";
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.$suggestSolution                = "ICSSM";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2022 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263x-cc_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263x --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.debug.lib
+                -lboard.am263x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.release.lib
+                -lboard.am263x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263x --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263x_beta --context r5fss0-0 --part AM263x --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263x-cc_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,273 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.18.0+3266"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2022 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263x --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.debug.lib
+                -lboard.am263x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.release.lib
+                -lboard.am263x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263x --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263x_beta --context r5fss0-0 --part AM263x --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,253 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM64x" --package "ALV" --part "Default" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.17.0+3128"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+mpu_armv76.$name    = "CONFIG_MPU_REGION5";
+mpu_armv76.baseAddr = 0x80000000;
+mpu_armv76.size     = 31;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x80;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0080;
+region1.memory_region[7].size               = 0x3F80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution = "UART0_TXD";

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM64x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am64x-evm_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM64x"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am64x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am64x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part Default --package ALV
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am64x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am64x.r5f.ti-arm-clang.debug.lib
+                -lboard.am64x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am64x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am64x.r5f.ti-arm-clang.release.lib
+                -lboard.am64x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,341 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am64x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM64X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am64x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am64x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am64x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am64x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am64x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am64x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part Default --package ALV --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM64x --context r5fss0-0 --part Default --package ALV --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,114 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am64x-evm_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/pru_add.c
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/pru_add.c
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_drivers_open_close.h"
+#include "ti_board_open_close.h"
+#include <drivers/pruicss.h>
+
+#include <pru0_load_bin.h>
+#include <pru1_load_bin.h>
+#if defined(SOC_AM64X) || defined(SOC_AM243X)
+#include <rtupru0_load_bin.h>
+#include <rtupru1_load_bin.h>
+#include <txpru0_load_bin.h>
+#include <txpru1_load_bin.h>
+#endif
+
+
+
+/*
+ *  This is an example project to show R5F
+ *  loading PRU firmware.
+ */
+
+/** \brief Global Structure pointer holding PRUSS1 memory Map. */
+
+PRUICSS_Handle gPruIcss0Handle;
+
+
+void pru_io_pru_add_main(void *args)
+{
+     Drivers_open(); // check return status
+
+     int status;
+     status = Board_driversOpen();
+     DebugP_assert(SystemP_SUCCESS == status);
+
+     gPruIcss0Handle = PRUICSS_open(CONFIG_PRU_ICSS0);
+
+     status = PRUICSS_initMemory(gPruIcss0Handle, PRUICSS_DATARAM(PRUICSS_PRU0));
+     DebugP_assert(status != 0);
+
+     status = PRUICSS_initMemory(gPruIcss0Handle, PRUICSS_DATARAM(PRUICSS_PRU1));
+     DebugP_assert(status != 0);
+
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_PRU0, PRU0Firmware_0, sizeof(PRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_PRU1, PRU1Firmware_0, sizeof(PRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+
+     #if defined(SOC_AM64X) || defined(SOC_AM243X)
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_RTU_PRU0, RTUPRU0Firmware_0, sizeof(RTUPRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_RTU_PRU1, RTUPRU1Firmware_0, sizeof(RTUPRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_TX_PRU0, TXPRU0Firmware_0, sizeof(TXPRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_TX_PRU1, TXPRU1Firmware_0, sizeof(TXPRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     #endif
+
+     while (1)
+     {
+        ClockP_usleep(1);
+     }
+
+     Board_driversClose();
+     Drivers_close();
+}

--- a/academy/getting_started_labs/c_and_assembly/solution/readme.md
+++ b/academy/getting_started_labs/c_and_assembly/solution/readme.md
@@ -1,0 +1,42 @@
+# PRU Getting Started Labs - getting started with mixed C and assembly
+
+## Introduction
+
+This example acts as a getting started point for PRU firmware development
+with mixed C and assembly.
+
+# Supported Combinations
+
+ Parameter      | Value
+ ---------------|-----------
+ ICSSG          | ICSSG0 - PRU0, PRU1, RTU0, RTU1, TX_PRU0,TX_PRU1
+ ICSSM          | ICSSM0 - PRU0, PRU1
+                | ICSSM1 - PRU0, PRU1 (am261x only)
+ Toolchain      | pru-cgt
+ Board          | am64x-evm, am243x-evm, am243x-lp, am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp
+ Example folder | academy/getting_started_labs/c_and_assembly/solution/
+
+# Steps to Run the Example
+
+> Prerequisite: [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt) should be installed at: `C:/ti/`
+
+- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU, After this `main.asm`, `linker.cmd` files gets copied to ccs workspace of PRU project. The `main.asm` contains sample code to halt PRU program
+
+     - Build the PRU project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
+          - Build Flow: Once you click on build in PRU project, firmware header file which is generated in release or debug folder of ccs workspace, is moved to  `<open-pru/academy/getting_started_labs/assembly_code/solution/firmware/device/>`
+
+     - Build the R5F project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
+          - Firmware header file path is included in R5F project include options by default, Instructions in Firmware header file can be written into PRU IRAM memory using PRUICSS_loadFirmware API (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe))
+          - Build Flow: Once you click on build in R5F project, SysConfig files are generated, Finally the R5F project will be generated using both the generated SysConfig and PRU project binaries.
+
+     - Launch a CCS debug session and run the executable, (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_LAUNCH_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_LAUNCH_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_LAUNCH_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_LAUNCH_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_LAUNCH_PAGE.html))
+
+- **When using makefiles to build**:
+     - For steps on how to use makefiles, run `make help` from the root folder
+       of the open-pru repository.
+
+# Writing PRU code
+
+* You can modify this example to write your own firmware. For more information,
+  refer to
+  [Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).

--- a/academy/getting_started_labs/c_and_inline_assembly/main.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/main.c
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (C) 2018-2025 Texas Instruments Incorporated - http://www.ti.com/
+ */
+
+#include <stdint.h>
+
+/* TODO: define c */
+/* a, b, and c are stored in a defined location in PRU memory */
+#define a  (*((volatile unsigned int *)0x110))
+#define b  (*((volatile unsigned int *)0x114))
+
+/* Declaration of the inline assembly function */
+uint32_t inline_assm_add(uint32_t arg1, uint32_t arg2);
+
+/*
+ * main.c
+ */
+void main(void)
+{
+	/* TODO: define y & z */
+	/* The compiler decides where to store x, y, and z */
+	uint32_t x = 1;
+
+	a = 1;
+	b = 2;
+
+	while(1) {
+		/*
+		 * TODO: use the inline assembly function to add x and y, then
+		 * store the sum in z
+		 */
+
+		/*
+		 * TODO: use the inline assembly function to add a and b, then
+		 * store the sum in memory location c
+		 */
+	}
+
+	/* This program will not reach __halt because of the while loop */
+	__halt();
+}
+
+/*
+ * inline_assm_add
+ */
+uint32_t inline_assm_add(uint32_t arg1, uint32_t arg2)
+{
+	/* 
+	 * Function input arguments are stored in R14-R29.
+	 * So the 32 bit value in arg1 is stored in R14, and the 32 bit value in
+	 * arg2 is stored in R15.
+ 	 * 
+	 * For more details about how function arguments
+	 * are stored in registers, reference the document "PRU Optimizing C/C+
+	 * Compiler User's Guide", section "Function Structure and Calling
+	 * Conventions"
+	 */
+
+	/*
+	 * For information about using __asm() to add inline assembly code,
+	 * reference the document "PRU Optimizing C/C+ Compiler User's Guide",
+	 * section "The __asm Statement".
+	 *
+	 * Note: You can use the newline and tab characters to place multiple
+	 * assembly instructions in a single __asm() call. For example:
+	 *
+	 * __asm("   assem_instr_1 \n\t assem_instr_2 \n\t assem_instr_3");
+	 */
+
+	/*
+	 * TODO: add arg1 and arg2
+	 */
+
+	/*
+	 * TODO: return the sum. The return value should be in R14.
+	 */
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU0	: org = 0x0002A000 len = 0x0000004C	CREGISTER=10
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU1	: org = 0x0002A200 len = 0x0000004C	CREGISTER=10
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_RTU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU0	: org = 0x0002A100 len = 0x0000004C	CREGISTER=10
+	RTU0_CTRL	: org = 0x00023000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_RTU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU1	: org = 0x0002A300 len = 0x0000004C	CREGISTER=10
+	RTU1_CTRL	: org = 0x00023800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU0	: org = 0x0002A400 len = 0x0000004C	CREGISTER=10
+	TX_PRU0_CTRL	: org = 0x00025000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU1	: org = 0x0002A500 len = 0x0000004C	CREGISTER=10
+	TX_PRU1_CTRL	: org = 0x00025800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU0	: org = 0x0002A000 len = 0x0000004C	CREGISTER=10
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU1	: org = 0x0002A200 len = 0x0000004C	CREGISTER=10
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_RTU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU0	: org = 0x0002A100 len = 0x0000004C	CREGISTER=10
+	RTU0_CTRL	: org = 0x00023000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_RTU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU1	: org = 0x0002A300 len = 0x0000004C	CREGISTER=10
+	RTU1_CTRL	: org = 0x00023800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU0	: org = 0x0002A400 len = 0x0000004C	CREGISTER=10
+	TX_PRU0_CTRL	: org = 0x00025000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU1	: org = 0x0002A500 len = 0x0000004C	CREGISTER=10
+	TX_PRU1_CTRL	: org = 0x00025800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-som_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-som_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-cc_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-cc_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_CC"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_CC"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-cc_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_CC"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_CC"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-cc_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_LAUNCHPAD"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_LAUNCHPAD"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM64x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU0	: org = 0x0002A000 len = 0x0000004C	CREGISTER=10
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM64x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU1	: org = 0x0002A200 len = 0x0000004C	CREGISTER=10
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM64x_RTU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x RTU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU0	: org = 0x0002A100 len = 0x0000004C	CREGISTER=10
+	RTU0_CTRL	: org = 0x00023000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM64x_RTU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x RTU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU1	: org = 0x0002A300 len = 0x0000004C	CREGISTER=10
+	RTU1_CTRL	: org = 0x00023800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM64x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x TX_PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU0	: org = 0x0002A400 len = 0x0000004C	CREGISTER=10
+	TX_PRU0_CTRL	: org = 0x00025000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM64x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x TX_PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU1	: org = 0x0002A500 len = 0x0000004C	CREGISTER=10
+	TX_PRU1_CTRL	: org = 0x00025800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/main.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/main.c
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (C) 2018-2025 Texas Instruments Incorporated - http://www.ti.com/
+ */
+
+#include <stdint.h>
+
+/* TODO: define c */
+/* a, b, and c are stored in a defined location in PRU memory */
+#define a  (*((volatile unsigned int *)0x110))
+#define b  (*((volatile unsigned int *)0x114))
+#define c  (*((volatile unsigned int *)0x118))
+
+/* Declaration of the inline assembly function */
+uint32_t inline_assm_add(uint32_t arg1, uint32_t arg2);
+
+/*
+ * main.c
+ */
+void main(void)
+{
+	/* TODO: define y & z */
+	/* The compiler decides where to store x, y, and z */
+	uint32_t x = 1;
+	uint32_t y = 2;
+	uint32_t z = 0;
+
+	a = 1;
+	b = 2;
+
+	while(1) {
+		/*
+		 * TODO: use the inline assembly function to add x and y, then
+		 * store the sum in z
+		 */
+		z = inline_assm_add(x, y);
+
+		/*
+		 * TODO: use the inline assembly function to add a and b, then
+		 * store the sum in memory location c
+		 */
+		c = inline_assm_add(a, b);
+	}
+
+	/* This program will not reach __halt because of the while loop */
+	__halt();
+}
+
+/*
+ * inline_assm_add
+ */
+uint32_t inline_assm_add(uint32_t arg1, uint32_t arg2)
+{
+	/* 
+	 * Function input arguments are stored in R14-R29.
+	 * So the 32 bit value in arg1 is stored in R14, and the 32 bit value in
+	 * arg2 is stored in R15.
+ 	 * 
+	 * For more details about how function arguments
+	 * are stored in registers, reference the document "PRU Optimizing C/C+
+	 * Compiler User's Guide", section "Function Structure and Calling
+	 * Conventions"
+	 */
+
+	/*
+	 * For information about using __asm() to add inline assembly code,
+	 * reference the document "PRU Optimizing C/C+ Compiler User's Guide",
+	 * section "The __asm Statement".
+	 *
+	 * Note: You can use the newline and tab characters to place multiple
+	 * assembly instructions in a single __asm() call. For example:
+	 *
+	 * __asm("   assem_instr_1 \n\t assem_instr_2 \n\t assem_instr_3");
+	 */
+
+	/*
+	 * TODO: add arg1 and arg2
+	 */
+	__asm("   ADD r14, r14, r15");
+
+	/*
+	 * TODO: return the sum. The return value should be in R14.
+	 */
+	return arg1;
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/makefile
@@ -1,0 +1,165 @@
+include ../../../../imports.mak
+
+#######################
+# project information #
+#######################
+
+PROJECT_NAME := pru_add
+SUPPORTED_PROCESSORS := am243x am261x am263px am263x am64x
+# Does the PRU code have dependencies outside of the open-pru repo?
+PRU_DEPENDENCIES :=
+# Use NON_PRU_DEPENDENCIES to select which makefiles to call for non-PRU cores
+NON_PRU_DEPENDENCIES := mcuplus
+
+###################
+# Prebuild checks #
+###################
+BUILD_PROJECT := y
+DEVICE_NON_PRU :=
+
+# Only build project if $(DEVICE) is in $(SUPPORTED_PROCESSORS)
+ifeq (,$(findstring $(DEVICE),$(SUPPORTED_PROCESSORS)))
+BUILD_PROJECT := n
+MESSAGE := Project $(PROJECT_NAME) does not have a build option for $(DEVICE)
+endif
+
+# Only build project if PRU dependencies exist
+ifneq (,$(PRU_DEPENDENCIES))
+# MCU+ SDK dependency?
+ifeq (mcuplus,$(findstring mcuplus,$(PRU_DEPENDENCIES)))
+ifneq ($(BUILD_MCUPLUS),y)
+BUILD_PROJECT := n
+MESSAGE ?= Project $(PROJECT_NAME) depends on MCU+ SDK, but BUILD_MCUPLUS != y.
+endif
+endif
+# Additional PRU dependency checks go here. For example:
+#ifeq (dependency,$(findstring dependency,$(PRU_DEPENDENCIES)))
+#if (dependency check fails)
+#BUILD_PROJECT := n
+#MESSAGE ?= Project $(PROJECT_NAME) depends on dependency, but dependency does not exist.
+#endif
+#endif
+endif
+
+# Only build non-PRU code if the non-PRU code is enabled in imports.mak
+ifeq ($(BUILD_MCUPLUS),y)
+ifeq (mcuplus,$(findstring mcuplus,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_mcuplus
+endif
+endif
+ifeq ($(BUILD_LINUX),y)
+ifeq (linux,$(findstring linux,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_linux
+endif
+endif
+
+###########################
+# Make and clean commands #
+###########################
+
+ifeq ($(BUILD_PROJECT),y)
+# "make" or "make all" builds projects that match $(DEVICE) set in imports.mak
+all: ARGUMENTS_PRU = all
+all: ARGUMENTS_MCUPLUS = $(ARGUMENTS_PRU)
+all: MESSAGE = "Building getting_started_labs/c_and_inline_assembly/$(PROJECT_NAME) for $(DEVICE)"
+all: pre_build_message $(DEVICE) $(DEVICE_NON_PRU)
+
+# "make clean" cleans projects that match $(DEVICE) set in imports.mak
+clean: ARGUMENTS_PRU = clean
+clean: ARGUMENTS_MCUPLUS = scrub
+clean: MESSAGE = "Cleaning getting_started_labs/c_and_inline_assembly/$(PROJECT_NAME) for $(DEVICE)"
+clean: pre_build_message $(DEVICE) $(DEVICE_NON_PRU)
+
+else
+# if a prebuild check failed, print message and exit
+all clean: pre_build_message
+endif
+
+pre_build_message:
+	@echo $(MESSAGE)
+
+######################
+# Target definitions #
+######################
+
+# provide target definitions for each supported processor
+# PRU firmware should be built before any RTOS code that includes it
+am243x:
+# am243x-evm
+	$(MAKE) -C firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am243x-lp
+	$(MAKE) -C firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am243x_mcuplus:
+# am243x-evm
+	$(MAKE) -C mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am243x-lp
+	$(MAKE) -C mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am261x:
+# am261x-lp
+	$(MAKE) -C firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am261x-som
+	$(MAKE) -C firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am261x_mcuplus:
+# am261x-lp
+	$(MAKE) -C mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am261x-som
+	$(MAKE) -C mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am263px:
+# am263px-lp
+	$(MAKE) -C firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am263px-cc
+	$(MAKE) -C firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am263px_mcuplus:
+# am263px-lp
+	$(MAKE) -C mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am263px-cc
+	$(MAKE) -C mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am263x:
+# am263x-lp
+	$(MAKE) -C firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am263x-cc
+	$(MAKE) -C firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am263x_mcuplus:
+# am263x-lp
+	$(MAKE) -C mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am263x-cc
+	$(MAKE) -C mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am64x:
+# am64x-evm
+	$(MAKE) -C firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am64x_mcuplus:
+# am64x-evm
+	$(MAKE) -C mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+.PHONY: all clean pre_build_message $(DEVICE) $(DEVICE_NON_PRU) $(SUPPORTED_PROCESSORS)
+

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,253 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALV_beta" --package "ALV" --part "ALV" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.00"
+ * @versions {"data":"2021012919","timestamp":"2021012919","tool":"1.8.0+1785","templates":null}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+const mpu_armv76 = mpu_armv7.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x180;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0180;
+region1.memory_region[7].size               = 0x3E80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+mpu_armv76.$name             = "CONFIG_MPU_REGION5";
+mpu_armv76.baseAddr          = 0x80000000;
+mpu_armv76.size              = 31;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution = "UART0_TXD";

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALV"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am243x-evm_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM2434_ALV"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALV --package ALV
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,340 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part ALV --package ALV --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM243x_ALV_beta --context r5fss0-0 --part ALV --package ALV --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,113 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am243x-evm_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,249 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALX_beta" --package "ALX" --part "ALX" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"data":"2021040816","timestamp":"2021040816","tool":"1.8.1+1900","templates":null}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x180;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0180;
+region1.memory_region[7].size               = 0x3E80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "B10";
+debug_log.uartLog.UART.TXD.$suggestSolution = "B11";

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALX"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am243x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM2434_ALX"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALX --package ALX
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,340 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part ALX --package ALX --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM243x_ALX_beta --context r5fss0-0 --part ALX --package ALX --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,113 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am243x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,291 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM261x_ZFG" --part "AM2612" --package "ZFG" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2612" --package "NFBGA (ZFG)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                    = "CONFIG_PRU_ICSS0";
+pruicss1.instance                                                                 = "ICSSM1";
+pruicss1.AdditionalICSSSettings[0].$name                                          = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                               = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO0.$assign = "GPIO81";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO0.$used   = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO8.$used   = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "GPIO27";
+debug_log.uartLog.UART.TXD.$assign = "GPIO28";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x70150000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x70154000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].$suggestSolution                = "PRU-ICSS1";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO8.$suggestSolution = "GPIO44";

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am261x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM261x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am261x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM2612 --package ZFG
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.debug.lib
+                -lboard.am261x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.release.lib
+                -lboard.am261x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM261X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am261x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM2612 --package ZFG --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM261x_ZFG --context r5fss0-0 --part AM2612 --package ZFG --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am261x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,276 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM261x_ZCZ" --part "AM2611" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2611" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name = "CONFIG_PRU_ICSS0";
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "GPIO27";
+debug_log.uartLog.UART.TXD.$assign = "GPIO28";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x70150000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x70154000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am261x-som_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM261x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am261x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM2611 --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.debug.lib
+                -lboard.am261x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.release.lib
+                -lboard.am261x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM261X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am261x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM2611 --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM261x_ZCZ --context r5fss0-0 --part AM2611 --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am261x-som_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,289 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_S" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-S)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                 = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                       = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                            = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.rx    = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$used = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].$suggestSolution                = "PRU-ICSS";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263Px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263px-cc_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263Px"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263px"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263P4 --package ZCZ_S
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.debug.lib
+                -lboard.am263px.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.release.lib
+                -lboard.am263px.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/linker.cmd
@@ -1,0 +1,137 @@
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=16384
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=32768
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is enabled
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 256;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 256;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > OCRAM
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > OCRAM
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > OCRAM
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > OCRAM
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > OCRAM
+
+    /* Sections needed for C++ projects */
+    GROUP {
+        .ARM.exidx:  {} palign(8)   /* Needed for C++ exception handling */
+        .init_array: {} palign(8)   /* Contains function pointers called before main */
+        .fini_array: {} palign(8)   /* Contains function pointers called after main */
+    } > OCRAM
+
+    /* General purpose user shared memory, used in some examples */
+    .bss.user_shared_mem (NOLOAD) : {} > USER_SHM_MEM
+    /* this is used when Debug log's to shared memory are enabled, else this is not used */
+    .bss.log_shared_mem  (NOLOAD) : {} > LOG_SHM_MEM
+    /* this is used only when IPC RPMessage is enabled, else this is not used */
+    .bss.ipc_vring_mem   (NOLOAD) : {} > RTOS_NORTOS_IPC_SHM_MEM
+    /* this is used only when Secure IPC is enabled */
+    .bss.sipc_hsm_queue_mem   (NOLOAD) : {} > MAILBOX_HSM
+    .bss.sipc_r5f_queue_mem   (NOLOAD) : {} > MAILBOX_R5F
+}
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB  : ORIGIN = 0x00080000 , LENGTH = 0x00008000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    OCRAM     : ORIGIN = 0x70040000 , LENGTH = 0x40000
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60100000 , LENGTH = 0x80000
+
+
+    /* shared memories that are used by RTOS/NORTOS cores */
+    /* On R5F,
+     * - make sure there is a MPU entry which maps below regions as non-cache
+     */
+    USER_SHM_MEM            : ORIGIN = 0x701D0000, LENGTH = 0x00004000
+    LOG_SHM_MEM             : ORIGIN = 0x701D4000, LENGTH = 0x00004000
+    /* MSS mailbox memory is used as shared memory, we dont use bottom 32*12 bytes, since its used as SW queue by ipc_notify */
+    RTOS_NORTOS_IPC_SHM_MEM : ORIGIN = 0x72000000, LENGTH = 0x3E80
+    MAILBOX_HSM:    ORIGIN = 0x44000000 , LENGTH = 0x000003CE
+    MAILBOX_R5F:    ORIGIN = 0x44000400 , LENGTH = 0x000003CE
+    }

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263PX \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263px:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263P4 --package ZCZ_S --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263Px --context r5fss0-0 --part AM263P4 --package ZCZ_S --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263px-cc_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,289 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_C" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-C)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                 = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                       = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                            = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.rx    = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$used = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].$suggestSolution                = "PRU-ICSS";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263Px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263px-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263Px"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263px"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263P4 --package ZCZ_C
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.debug.lib
+                -lboard.am263px.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.release.lib
+                -lboard.am263px.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/linker.cmd
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/linker.cmd
@@ -1,0 +1,137 @@
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=16384
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=32768
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is enabled
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 256;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 256;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > OCRAM
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > OCRAM
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > OCRAM
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > OCRAM
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > OCRAM
+
+    /* Sections needed for C++ projects */
+    GROUP {
+        .ARM.exidx:  {} palign(8)   /* Needed for C++ exception handling */
+        .init_array: {} palign(8)   /* Contains function pointers called before main */
+        .fini_array: {} palign(8)   /* Contains function pointers called after main */
+    } > OCRAM
+
+    /* General purpose user shared memory, used in some examples */
+    .bss.user_shared_mem (NOLOAD) : {} > USER_SHM_MEM
+    /* this is used when Debug log's to shared memory are enabled, else this is not used */
+    .bss.log_shared_mem  (NOLOAD) : {} > LOG_SHM_MEM
+    /* this is used only when IPC RPMessage is enabled, else this is not used */
+    .bss.ipc_vring_mem   (NOLOAD) : {} > RTOS_NORTOS_IPC_SHM_MEM
+    /* this is used only when Secure IPC is enabled */
+    .bss.sipc_hsm_queue_mem   (NOLOAD) : {} > MAILBOX_HSM
+    .bss.sipc_r5f_queue_mem   (NOLOAD) : {} > MAILBOX_R5F
+}
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB  : ORIGIN = 0x00080000 , LENGTH = 0x00008000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    OCRAM     : ORIGIN = 0x70040000 , LENGTH = 0x40000
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60100000 , LENGTH = 0x80000
+
+
+    /* shared memories that are used by RTOS/NORTOS cores */
+    /* On R5F,
+     * - make sure there is a MPU entry which maps below regions as non-cache
+     */
+    USER_SHM_MEM            : ORIGIN = 0x701D0000, LENGTH = 0x00004000
+    LOG_SHM_MEM             : ORIGIN = 0x701D4000, LENGTH = 0x00004000
+    /* MSS mailbox memory is used as shared memory, we dont use bottom 32*12 bytes, since its used as SW queue by ipc_notify */
+    RTOS_NORTOS_IPC_SHM_MEM : ORIGIN = 0x72000000, LENGTH = 0x3E80
+    MAILBOX_HSM:    ORIGIN = 0x44000000 , LENGTH = 0x000003CE
+    MAILBOX_R5F:    ORIGIN = 0x44000400 , LENGTH = 0x000003CE
+    }

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263PX \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263px:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263P4 --package ZCZ_C --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263Px --context r5fss0-0 --part AM263P4 --package ZCZ_C --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263px-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,295 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @versions {"tool":"1.23.0+4000"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+const output_xbar     = scripting.addModule("/xbar/output_xbar/output_xbar", {}, false);
+const output_xbar1    = output_xbar.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                              = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                    = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                         = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.slewRate = "high";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.$used    = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+output_xbar1.$name                         = "CONFIG_OUTPUT_XBAR0";
+output_xbar1.xbarOutput                    = ["EPWM0_TRIPOUT"];
+output_xbar1.OUTPUTXBAR.$assign            = "OUTPUTXBAR0";
+output_xbar1.OUTPUTXBAR.OUTPUTXBAR.$assign = "QSPI_CSn1";
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.$suggestSolution                = "ICSSM";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2022 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263x-cc_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263x --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.debug.lib
+                -lboard.am263x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.release.lib
+                -lboard.am263x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263x --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263x_beta --context r5fss0-0 --part AM263x --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263x-cc_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,273 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.18.0+3266"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2022 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263x --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.debug.lib
+                -lboard.am263x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.release.lib
+                -lboard.am263x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263x --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263x_beta --context r5fss0-0 --part AM263x --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,253 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM64x" --package "ALV" --part "Default" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.17.0+3128"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+mpu_armv76.$name    = "CONFIG_MPU_REGION5";
+mpu_armv76.baseAddr = 0x80000000;
+mpu_armv76.size     = 31;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x80;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0080;
+region1.memory_region[7].size               = 0x3F80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution = "UART0_TXD";

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM64x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am64x-evm_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM64x"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am64x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am64x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part Default --package ALV
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am64x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am64x.r5f.ti-arm-clang.debug.lib
+                -lboard.am64x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am64x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am64x.r5f.ti-arm-clang.release.lib
+                -lboard.am64x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,341 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am64x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM64X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am64x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am64x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am64x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am64x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am64x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am64x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part Default --package ALV --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM64x --context r5fss0-0 --part Default --package ALV --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,114 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am64x-evm_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/pru_add.c
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/pru_add.c
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_drivers_open_close.h"
+#include "ti_board_open_close.h"
+#include <drivers/pruicss.h>
+
+#include <pru0_load_bin.h>
+#include <pru1_load_bin.h>
+#if defined(SOC_AM64X) || defined(SOC_AM243X)
+#include <rtupru0_load_bin.h>
+#include <rtupru1_load_bin.h>
+#include <txpru0_load_bin.h>
+#include <txpru1_load_bin.h>
+#endif
+
+
+
+/*
+ *  This is an example project to show R5F
+ *  loading PRU firmware.
+ */
+
+/** \brief Global Structure pointer holding PRUSS1 memory Map. */
+
+PRUICSS_Handle gPruIcss0Handle;
+
+
+void pru_io_pru_add_main(void *args)
+{
+     Drivers_open(); // check return status
+
+     int status;
+     status = Board_driversOpen();
+     DebugP_assert(SystemP_SUCCESS == status);
+
+     gPruIcss0Handle = PRUICSS_open(CONFIG_PRU_ICSS0);
+
+     status = PRUICSS_initMemory(gPruIcss0Handle, PRUICSS_DATARAM(PRUICSS_PRU0));
+     DebugP_assert(status != 0);
+
+     status = PRUICSS_initMemory(gPruIcss0Handle, PRUICSS_DATARAM(PRUICSS_PRU1));
+     DebugP_assert(status != 0);
+
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_PRU0, PRU0Firmware_0, sizeof(PRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_PRU1, PRU1Firmware_0, sizeof(PRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+
+     #if defined(SOC_AM64X) || defined(SOC_AM243X)
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_RTU_PRU0, RTUPRU0Firmware_0, sizeof(RTUPRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_RTU_PRU1, RTUPRU1Firmware_0, sizeof(RTUPRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_TX_PRU0, TXPRU0Firmware_0, sizeof(TXPRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_TX_PRU1, TXPRU1Firmware_0, sizeof(TXPRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     #endif
+
+     while (1)
+     {
+        ClockP_usleep(1);
+     }
+
+     Board_driversClose();
+     Drivers_close();
+}

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/readme.md
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/readme.md
@@ -1,0 +1,42 @@
+# PRU Getting Started Labs - getting started with mixed C and assembly
+
+## Introduction
+
+This example acts as a getting started point for PRU firmware development with
+mixed C and inline assembly.
+
+# Supported Combinations
+
+ Parameter      | Value
+ ---------------|-----------
+ ICSSG          | ICSSG0 - PRU0, PRU1, RTU0, RTU1, TX_PRU0,TX_PRU1
+ ICSSM          | ICSSM0 - PRU0, PRU1
+                | ICSSM1 - PRU0, PRU1 (am261x only)
+ Toolchain      | pru-cgt
+ Board          | am64x-evm, am243x-evm, am243x-lp, am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp
+ Example folder | academy/getting_started_labs/c_and_inline_assembly/solution/
+
+# Steps to Run the Example
+
+> Prerequisite: [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt) should be installed at: `C:/ti/`
+
+- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU, After this `main.asm`, `linker.cmd` files gets copied to ccs workspace of PRU project. The `main.asm` contains sample code to halt PRU program
+
+     - Build the PRU project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
+          - Build Flow: Once you click on build in PRU project, firmware header file which is generated in release or debug folder of ccs workspace, is moved to  `<open-pru/academy/getting_started_labs/assembly_code/solution/firmware/device/>`
+
+     - Build the R5F project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
+          - Firmware header file path is included in R5F project include options by default, Instructions in Firmware header file can be written into PRU IRAM memory using PRUICSS_loadFirmware API (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe))
+          - Build Flow: Once you click on build in R5F project, SysConfig files are generated, Finally the R5F project will be generated using both the generated SysConfig and PRU project binaries.
+
+     - Launch a CCS debug session and run the executable, (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_LAUNCH_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_LAUNCH_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_LAUNCH_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_LAUNCH_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_LAUNCH_PAGE.html))
+
+- **When using makefiles to build**:
+     - For steps on how to use makefiles, run `make help` from the root folder
+       of the open-pru repository.
+
+# Writing PRU code
+
+* You can modify this example to write your own firmware. For more information,
+  refer to
+  [Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).

--- a/academy/getting_started_labs/c_code/main.c
+++ b/academy/getting_started_labs/c_code/main.c
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (C) 2018-2025 Texas Instruments Incorporated - http://www.ti.com/
+ */
+#include <stdint.h>
+
+/* TODO: define c */
+/* a, b, and c are stored in a defined location in PRU memory */
+#define a  (*((volatile unsigned int *)0x110))
+#define b  (*((volatile unsigned int *)0x114))
+
+/*
+ * main.c
+ */
+void main(void)
+{
+	/* TODO: define y & z */
+	/* The compiler decides where to store x, y, and z */
+	uint32_t x = 1;
+
+	a = 1;
+	b = 2;
+
+	while(1) {
+		/*
+		 * TODO: store the sum of x and y in z
+		 */
+
+		/*
+		 * TODO: store the sum of the numbers at memory locations a and
+		 * b in memory location c
+		 */
+	}
+
+	/* This program will not reach __halt because of the while loop */
+	__halt();
+}
+

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU0	: org = 0x0002A000 len = 0x0000004C	CREGISTER=10
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU1	: org = 0x0002A200 len = 0x0000004C	CREGISTER=10
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_RTU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU0	: org = 0x0002A100 len = 0x0000004C	CREGISTER=10
+	RTU0_CTRL	: org = 0x00023000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_RTU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU1	: org = 0x0002A300 len = 0x0000004C	CREGISTER=10
+	RTU1_CTRL	: org = 0x00023800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU0	: org = 0x0002A400 len = 0x0000004C	CREGISTER=10
+	TX_PRU0_CTRL	: org = 0x00025000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU1	: org = 0x0002A500 len = 0x0000004C	CREGISTER=10
+	TX_PRU1_CTRL	: org = 0x00025800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-evm_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU0	: org = 0x0002A000 len = 0x0000004C	CREGISTER=10
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU1	: org = 0x0002A200 len = 0x0000004C	CREGISTER=10
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_RTU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU0	: org = 0x0002A100 len = 0x0000004C	CREGISTER=10
+	RTU0_CTRL	: org = 0x00023000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_RTU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x RTU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU1	: org = 0x0002A300 len = 0x0000004C	CREGISTER=10
+	RTU1_CTRL	: org = 0x00023800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM243x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU0	: org = 0x0002A400 len = 0x0000004C	CREGISTER=10
+	TX_PRU0_CTRL	: org = 0x00025000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM243x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM243x_LAUNCHPAD"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM243x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM243x TX_PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU1	: org = 0x0002A500 len = 0x0000004C	CREGISTER=10
+	TX_PRU1_CTRL	: org = 0x00025800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am243x-lp_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am243x-lp_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-som/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-som/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-som_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am261x-som/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-som_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM261x"
+        deviceCore="ICSS_M0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-som/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-som/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM261x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM261x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am261x-som_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am261x-som/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am261x-som_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-cc_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-cc_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-cc_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-cc_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --package "ZCZ_C" --part "AM263P1" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263px"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263px_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263px PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263px-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263px-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_CC"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_CC"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-cc_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-cc_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_CC"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_CC"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-cc_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-cc_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_LAUNCHPAD"
+        deviceCore="ICSSM_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-lp_icss_m0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-lp_icss_m0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/example.syscfg
@@ -1,0 +1,6 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "icss_m0_pru1" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.20.0+3587"}
+ */

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM263x_LAUNCHPAD"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM263x_LAUNCHPAD"
+        deviceCore="ICSSM_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM263x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM263x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,150 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am263x-lp_icss_m0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v3 -Ooff \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am263x-lp_icss_m0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware  -o pru0_load_bin.h pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/pru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM64x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU0	: org = 0x0002A000 len = 0x0000004C	CREGISTER=10
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_pru0_fw
+HEX_ARRAY_PREFIX := PRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware  -o pru1_load_bin.h pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm pru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h pru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/pru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm pru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM64x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU1	: org = 0x0002A200 len = 0x0000004C	CREGISTER=10
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_pru1_fw
+HEX_ARRAY_PREFIX := PRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU0Firmware  -o rtupru0_load_bin.h pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/rtupru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM64x_RTU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x RTU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU0	: org = 0x0002A100 len = 0x0000004C	CREGISTER=10
+	RTU0_CTRL	: org = 0x00023000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU0_DMEM_0, PAGE 1
+	.bss		>  RTU0_DMEM_0, PAGE 1
+	.cio		>  RTU0_DMEM_0, PAGE 1
+	.data		>  RTU0_DMEM_0, PAGE 1
+	.switch		>  RTU0_DMEM_0, PAGE 1
+	.sysmem		>  RTU0_DMEM_0, PAGE 1
+	.cinit		>  RTU0_DMEM_0, PAGE 1
+	.rodata		>  RTU0_DMEM_0, PAGE 1
+	.rofardata	>  RTU0_DMEM_0, PAGE 1
+	.farbss		>  RTU0_DMEM_0, PAGE 1
+	.fardata	>  RTU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_rtu_pru0_fw
+HEX_ARRAY_PREFIX := RTUPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_rtu_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_RTU_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DRTU_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=RTUPRU1Firmware  -o rtupru1_load_bin.h pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm rtupru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h rtupru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/rtupru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm rtupru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM64x_RTU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x RTU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 8 KB RTU Instruction RAM */
+	RTU_IMEM	: org = 0x00000000 len = 0x00002000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_RTU1	: org = 0x0002A300 len = 0x0000004C	CREGISTER=10
+	RTU1_CTRL	: org = 0x00023800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of RTU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  RTU_IMEM, PAGE 0
+	.stack		>  RTU1_DMEM_1, PAGE 1
+	.bss		>  RTU1_DMEM_1, PAGE 1
+	.cio		>  RTU1_DMEM_1, PAGE 1
+	.data		>  RTU1_DMEM_1, PAGE 1
+	.switch		>  RTU1_DMEM_1, PAGE 1
+	.sysmem		>  RTU1_DMEM_1, PAGE 1
+	.cinit		>  RTU1_DMEM_1, PAGE 1
+	.rodata		>  RTU1_DMEM_1, PAGE 1
+	.rofardata	>  RTU1_DMEM_1, PAGE 1
+	.farbss		>  RTU1_DMEM_1, PAGE 1
+	.fardata	>  RTU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_rtu_pru1_fw
+HEX_ARRAY_PREFIX := RTUPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := rtupru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_rtu_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU0Firmware  -o txpru0_load_bin.h pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru0_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru0_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/txpru0_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru0_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM64x_TX_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x TX_PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU0_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU0	: org = 0x0002A400 len = 0x0000004C	CREGISTER=10
+	TX_PRU0_CTRL	: org = 0x00025000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU0_DMEM_0, PAGE 1
+	.bss		>  TX_PRU0_DMEM_0, PAGE 1
+	.cio		>  TX_PRU0_DMEM_0, PAGE 1
+	.data		>  TX_PRU0_DMEM_0, PAGE 1
+	.switch		>  TX_PRU0_DMEM_0, PAGE 1
+	.sysmem		>  TX_PRU0_DMEM_0, PAGE 1
+	.cinit		>  TX_PRU0_DMEM_0, PAGE 1
+	.rodata		>  TX_PRU0_DMEM_0, PAGE 1
+	.rofardata	>  TX_PRU0_DMEM_0, PAGE 1
+	.farbss		>  TX_PRU0_DMEM_0, PAGE 1
+	.fardata	>  TX_PRU0_DMEM_0, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_tx_pru0_fw
+HEX_ARRAY_PREFIX := TXPRU0Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru0_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_tx_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty"
+        name = "pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_TX_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/common
+            -DTX_PRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -m=pru_add.${ConfigName}.map
+            --disable_auto_rts
+            --entry_point=main
+            --diag_suppress=10063-D
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=TXPRU1Firmware  -o txpru1_load_bin.h pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt.out;if ${CCS_HOST_OS} == linux cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == linux rm txpru1_load_bin.h;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/cat ${MCU_PLUS_SDK_PATH}/source/pru_io/firmware/pru_load_bin_copyright.h txpru1_load_bin.h > ${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/txpru1_load_bin.h ;if ${CCS_HOST_OS} == win32  $(CCS_INSTALL_DIR)/utils/cygwin/rm txpru1_load_bin.h;
+        "
+
+        description="A Empty FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -O3
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.asm" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM64x_TX_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x TX_PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 6 KB TX_PRU Instruction RAM */
+	TX_PRU_IMEM	: org = 0x00000000 len = 0x00001800
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU1_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/c_code/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_TX_PRU1	: org = 0x0002A500 len = 0x0000004C	CREGISTER=10
+	TX_PRU1_CTRL	: org = 0x00025800 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of Tx_PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  TX_PRU_IMEM, PAGE 0
+	.stack		>  TX_PRU1_DMEM_1, PAGE 1
+	.bss		>  TX_PRU1_DMEM_1, PAGE 1
+	.cio		>  TX_PRU1_DMEM_1, PAGE 1
+	.data		>  TX_PRU1_DMEM_1, PAGE 1
+	.switch		>  TX_PRU1_DMEM_1, PAGE 1
+	.sysmem		>  TX_PRU1_DMEM_1, PAGE 1
+	.cinit		>  TX_PRU1_DMEM_1, PAGE 1
+	.rodata		>  TX_PRU1_DMEM_1, PAGE 1
+	.rofardata	>  TX_PRU1_DMEM_1, PAGE 1
+	.farbss		>  TX_PRU1_DMEM_1, PAGE 1
+	.fardata	>  TX_PRU1_DMEM_1, PAGE 1
+}

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,149 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := pru_add_am64x-evm_icss_g0_tx_pru1_fw
+HEX_ARRAY_PREFIX := TXPRU1Firmware
+GEN_DIR := generated
+TARGET := $(GEN_DIR)/$(OUTPUT_NAME).out
+TARGET_HEX := $(GEN_DIR)/$(OUTPUT_NAME).h
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := txpru1_load_bin.h
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+vpath %.asm $(FILES_PATH)
+vpath %.c $(FILES_PATH)
+vpath %.cmd $(FILES_PATH)
+vpath %.obj $(GEN_DIR)
+C_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c)))
+ASM_FILES := $(notdir $(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm)))
+
+# Generate an object file for every *.asm and *.c source file in FILES_PATH
+OBJECTS := $(patsubst %.asm, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.asm))))
+OBJECTS += $(patsubst %.c, $(GEN_DIR)/%.obj, $(notdir \
+	$(foreach directory, $(FILES_PATH), $(wildcard $(directory)/*.c))))
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Include paths
+INCLUDE := \
+	--include_path=$(CGT_TI_PRU_PATH)/include \
+	--include_path=$(OPEN_PRU_PATH)/source
+ifeq ($(BUILD_MCUPLUS),y)
+INCLUDE += \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source \
+	--include_path=$(MCU_PLUS_SDK_PATH)/source/pru_io/firmware/common
+endif
+
+# Compiler flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+# commonly modified flags include:
+#     silicon version: -v (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+#     C code optimization: -O (off, 0, 1, 2, 3, 4)
+CFLAGS := \
+	-v4 -Ooff \
+	--display_error_number --diag_wrap=off --diag_warning=225 \
+	--asm_directory=$(GEN_DIR) --obj_directory=$(GEN_DIR) --pp_directory=$(GEN_DIR) \
+	-ppd -ppa -g --endian=little
+
+# Linker flags (Defined in 'PRU Optimizing C/C++ Compiler User's Guide)
+LFLAGS := \
+	-m$(GEN_DIR)/$(OUTPUT_NAME).map --xml_link_info=$(GEN_DIR)/$(OUTPUT_NAME)_linkInfo.xml \
+	--display_error_number --diag_wrap=off --diag_warning=225 --diag_suppress=10063-D \
+	--warn_sections --reread_libs
+
+ifeq ($(C_FILES),)
+# PRU firmware is assembly-only
+# commonly modified flags include:
+#     entry point
+LFLAGS += \
+	--entry_point=main --disable_auto_rts --ram_model
+
+else
+# PRU firmware has C code
+# commonly modified flags include:
+#     stack size, heap size
+LFLAGS += \
+	--stack_size=0x100 --heap_size=0x100 \
+	-i$(CGT_TI_PRU_PATH)/lib -i$(CGT_TI_PRU_PATH)/include --library=libc.a
+endif
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+
+# Only build if tools are defined
+ifeq (,$(CGT_TI_PRU_PATH))
+all clean:
+	@echo 'CGT_TI_PRU_PATH not set. Make sure that:'
+	@echo ' 1) OPEN_PRU_PATH points to the open-pru repo'
+	@echo ' 2) imports.mak exists at OPEN_PRU_PATH'
+	@echo ' 3) Both the open-pru repo and imports.mak are set up as per'
+	@echo '    OPEN_PRU_PATH/docs/getting_started.md'
+else
+
+# All Target
+all: $(OBJECTS) $(COMMAND_FILES)
+	@$(MAKE) --no-print-directory -Onone "$(TARGET)"
+
+# Invoke the compiler on all assembly files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.asm
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: "$^"'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the compiler on all c files in vpath to create the object files
+$(GEN_DIR)/%.obj: %.c
+	$(MKDIR) $(GEN_DIR)
+	@echo 'Building file: $^'
+	@echo 'Invoking: PRU Compiler'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(INCLUDE) $(CFLAGS) $(DFLAGS) $^
+	@echo 'Finished building: "$^"'
+	@echo ' '
+
+# Invoke the linker (-z flag) to make the .out file
+$(TARGET): $(OBJECTS) $(COMMAND_FILES)
+	@echo 'Building target: "$@"'
+	@echo 'Invoking: PRU Linker'
+	"$(CGT_TI_PRU_PATH)/bin/clpru" $(CFLAGS) -z $^ $(LFLAGS) -o $(TARGET) $(LIBS)
+	@echo 'Finished building target: "$@"'
+	@echo ' '
+	@$(MAKE) --no-print-directory post-build
+
+# To clean generated files
+clean:
+	-$(RMDIR) $(GEN_DIR)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(RM) $(MCU_HEX_PATH)
+endif
+	@echo 'Finished clean'
+	@echo ' '
+endif
+
+# Generate hex array
+post-build:
+	-$(CGT_TI_PRU_PATH)/bin/hexpru --diag_wrap=off --array --array:name_prefix=$(HEX_ARRAY_PREFIX) -o $(TARGET_HEX) $(TARGET)
+	-$(CAT) $(OPEN_PRU_PATH)/source/firmware/pru_load_bin_copyright.h $(TARGET_HEX) > $(TARGET_HEX).temp
+	-$(MOVE) $(TARGET_HEX).temp $(TARGET_HEX)
+ifeq ($(BUILD_MCUPLUS),y)
+	-$(COPY) $(TARGET_HEX) $(MCU_HEX_PATH)
+endif
+	@echo ' '
+
+.PHONY: all clean
+
+# Include the dependencies that the compiler creates (-ppd and -ppa flags)
+-include $(OBJECTS:%.obj=%.pp)

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_am64x-evm_icss_g0_tx_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/firmware/main.c
+++ b/academy/getting_started_labs/c_code/solution/firmware/main.c
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (C) 2018-2025 Texas Instruments Incorporated - http://www.ti.com/
+ */
+
+#include <stdint.h>
+
+/* TODO: define c */
+/* a, b, and c are stored in a defined location in PRU memory */
+#define a  (*((volatile unsigned int *)0x110))
+#define b  (*((volatile unsigned int *)0x114))
+#define c  (*((volatile unsigned int *)0x118))
+
+/*
+ * main.c
+ */
+void main(void)
+{
+	/* TODO: define y & z */
+	/* The compiler decides where to store x, y, and z */
+	uint32_t x = 1;
+	uint32_t y = 2;
+	uint32_t z = 0;
+
+	a = 1;
+	b = 2;
+
+	while(1) {
+		/*
+		 * TODO: store the sum of x and y in z
+		 */
+		z = x + y;
+
+		/*
+		 * TODO: store the sum of the numbers at memory locations a and
+		 * b in memory location c
+		 */
+		c = a + b;
+	}
+
+	/* This program will not reach __halt because of the while loop */
+	__halt();
+}
+

--- a/academy/getting_started_labs/c_code/solution/makefile
+++ b/academy/getting_started_labs/c_code/solution/makefile
@@ -1,0 +1,165 @@
+include ../../../../imports.mak
+
+#######################
+# project information #
+#######################
+
+PROJECT_NAME := pru_add
+SUPPORTED_PROCESSORS := am243x am261x am263px am263x am64x
+# Does the PRU code have dependencies outside of the open-pru repo?
+PRU_DEPENDENCIES :=
+# Use NON_PRU_DEPENDENCIES to select which makefiles to call for non-PRU cores
+NON_PRU_DEPENDENCIES := mcuplus
+
+###################
+# Prebuild checks #
+###################
+BUILD_PROJECT := y
+DEVICE_NON_PRU :=
+
+# Only build project if $(DEVICE) is in $(SUPPORTED_PROCESSORS)
+ifeq (,$(findstring $(DEVICE),$(SUPPORTED_PROCESSORS)))
+BUILD_PROJECT := n
+MESSAGE := Project $(PROJECT_NAME) does not have a build option for $(DEVICE)
+endif
+
+# Only build project if PRU dependencies exist
+ifneq (,$(PRU_DEPENDENCIES))
+# MCU+ SDK dependency?
+ifeq (mcuplus,$(findstring mcuplus,$(PRU_DEPENDENCIES)))
+ifneq ($(BUILD_MCUPLUS),y)
+BUILD_PROJECT := n
+MESSAGE ?= Project $(PROJECT_NAME) depends on MCU+ SDK, but BUILD_MCUPLUS != y.
+endif
+endif
+# Additional PRU dependency checks go here. For example:
+#ifeq (dependency,$(findstring dependency,$(PRU_DEPENDENCIES)))
+#if (dependency check fails)
+#BUILD_PROJECT := n
+#MESSAGE ?= Project $(PROJECT_NAME) depends on dependency, but dependency does not exist.
+#endif
+#endif
+endif
+
+# Only build non-PRU code if the non-PRU code is enabled in imports.mak
+ifeq ($(BUILD_MCUPLUS),y)
+ifeq (mcuplus,$(findstring mcuplus,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_mcuplus
+endif
+endif
+ifeq ($(BUILD_LINUX),y)
+ifeq (linux,$(findstring linux,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_linux
+endif
+endif
+
+###########################
+# Make and clean commands #
+###########################
+
+ifeq ($(BUILD_PROJECT),y)
+# "make" or "make all" builds projects that match $(DEVICE) set in imports.mak
+all: ARGUMENTS_PRU = all
+all: ARGUMENTS_MCUPLUS = $(ARGUMENTS_PRU)
+all: MESSAGE = "Building getting_started_labs/c_code/$(PROJECT_NAME) for $(DEVICE)"
+all: pre_build_message $(DEVICE) $(DEVICE_NON_PRU)
+
+# "make clean" cleans projects that match $(DEVICE) set in imports.mak
+clean: ARGUMENTS_PRU = clean
+clean: ARGUMENTS_MCUPLUS = scrub
+clean: MESSAGE = "Cleaning getting_started_labs/c_code/$(PROJECT_NAME) for $(DEVICE)"
+clean: pre_build_message $(DEVICE) $(DEVICE_NON_PRU)
+
+else
+# if a prebuild check failed, print message and exit
+all clean: pre_build_message
+endif
+
+pre_build_message:
+	@echo $(MESSAGE)
+
+######################
+# Target definitions #
+######################
+
+# provide target definitions for each supported processor
+# PRU firmware should be built before any RTOS code that includes it
+am243x:
+# am243x-evm
+	$(MAKE) -C firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am243x-lp
+	$(MAKE) -C firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am243x_mcuplus:
+# am243x-evm
+	$(MAKE) -C mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am243x-lp
+	$(MAKE) -C mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am261x:
+# am261x-lp
+	$(MAKE) -C firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am261x-som
+	$(MAKE) -C firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am261x_mcuplus:
+# am261x-lp
+	$(MAKE) -C mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am261x-som
+	$(MAKE) -C mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am263px:
+# am263px-lp
+	$(MAKE) -C firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am263px-cc
+	$(MAKE) -C firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am263px_mcuplus:
+# am263px-lp
+	$(MAKE) -C mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am263px-cc
+	$(MAKE) -C mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am263x:
+# am263x-lp
+	$(MAKE) -C firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+# am263x-cc
+	$(MAKE) -C firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am263x_mcuplus:
+# am263x-lp
+	$(MAKE) -C mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+# am263x-cc
+	$(MAKE) -C mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+am64x:
+# am64x-evm
+	$(MAKE) -C firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am64x_mcuplus:
+# am64x-evm
+	$(MAKE) -C mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang $(ARGUMENTS_MCUPLUS)
+
+.PHONY: all clean pre_build_message $(DEVICE) $(DEVICE_NON_PRU) $(SUPPORTED_PROCESSORS)
+

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,253 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALV_beta" --package "ALV" --part "ALV" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.00"
+ * @versions {"data":"2021012919","timestamp":"2021012919","tool":"1.8.0+1785","templates":null}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+const mpu_armv76 = mpu_armv7.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x180;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0180;
+region1.memory_region[7].size               = 0x3E80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+mpu_armv76.$name             = "CONFIG_MPU_REGION5";
+mpu_armv76.baseAddr          = 0x80000000;
+mpu_armv76.size              = 31;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution = "UART0_TXD";

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALV"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am243x-evm_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM2434_ALV"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALV --package ALV
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,340 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-evm \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part ALV --package ALV --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM243x_ALV_beta --context r5fss0-0 --part ALV --package ALV --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,113 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am243x-evm_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,249 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM243x_ALX_beta" --package "ALX" --part "ALX" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"data":"2021040816","timestamp":"2021040816","tool":"1.8.1+1900","templates":null}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+const debug_log  = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7  = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71 = mpu_armv7.addInstance();
+const mpu_armv72 = mpu_armv7.addInstance();
+const mpu_armv73 = mpu_armv7.addInstance();
+const mpu_armv74 = mpu_armv7.addInstance();
+const mpu_armv75 = mpu_armv7.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x180;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0180;
+region1.memory_region[7].size               = 0x3E80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "B10";
+debug_log.uartLog.UART.TXD.$suggestSolution = "B11";

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM2434_ALX"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am243x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM243X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM2434_ALX"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM243X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am243x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part ALX --package ALX
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.debug.lib
+                -lboard.am243x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am243x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am243x.r5f.ti-arm-clang.release.lib
+                -lboard.am243x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM243X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,340 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am243x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am243x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM243X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am243x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am243x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am243x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am243x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am243x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part ALX --package ALX --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM243x_ALX_beta --context r5fss0-0 --part ALX --package ALX --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,113 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am243x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am243x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,291 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM261x_ZFG" --part "AM2612" --package "ZFG" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2612" --package "NFBGA (ZFG)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                    = "CONFIG_PRU_ICSS0";
+pruicss1.instance                                                                 = "ICSSM1";
+pruicss1.AdditionalICSSSettings[0].$name                                          = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                               = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO0.$assign = "GPIO81";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO0.$used   = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO8.$used   = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "GPIO27";
+debug_log.uartLog.UART.TXD.$assign = "GPIO28";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x70150000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x70154000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].$suggestSolution                = "PRU-ICSS1";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS1"].PR1_PRU0_GPIO8.$suggestSolution = "GPIO44";

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am261x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM261x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am261x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM2612 --package ZFG
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.debug.lib
+                -lboard.am261x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.release.lib
+                -lboard.am261x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM261X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am261x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM2612 --package ZFG --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM261x_ZFG --context r5fss0-0 --part AM2612 --package ZFG --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am261x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,276 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM261x_ZCZ" --part "AM2611" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM2611" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name = "CONFIG_PRU_ICSS0";
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "GPIO27";
+debug_log.uartLog.UART.TXD.$assign = "GPIO28";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x70150000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x70154000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM261x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am261x-som_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM261X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM261x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-som
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM261X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am261x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM2611 --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.debug.lib
+                -lboard.am261x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am261x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am261x.r5f.ti-arm-clang.release.lib
+                -lboard.am261x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM261X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am261x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am261x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am261x-som \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM261X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am261x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am261x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am261x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am261x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am261x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM2611 --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM261x_ZCZ --context r5fss0-0 --part AM2611 --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am261x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am261x-som_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,289 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_S" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-S)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                 = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                       = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                            = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.rx    = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$used = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].$suggestSolution                = "PRU-ICSS";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263Px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263px-cc_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263Px"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-cc
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263px"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263P4 --package ZCZ_S
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.debug.lib
+                -lboard.am263px.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.release.lib
+                -lboard.am263px.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/linker.cmd
@@ -1,0 +1,137 @@
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=16384
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=32768
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is enabled
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 256;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 256;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > OCRAM
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > OCRAM
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > OCRAM
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > OCRAM
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > OCRAM
+
+    /* Sections needed for C++ projects */
+    GROUP {
+        .ARM.exidx:  {} palign(8)   /* Needed for C++ exception handling */
+        .init_array: {} palign(8)   /* Contains function pointers called before main */
+        .fini_array: {} palign(8)   /* Contains function pointers called after main */
+    } > OCRAM
+
+    /* General purpose user shared memory, used in some examples */
+    .bss.user_shared_mem (NOLOAD) : {} > USER_SHM_MEM
+    /* this is used when Debug log's to shared memory are enabled, else this is not used */
+    .bss.log_shared_mem  (NOLOAD) : {} > LOG_SHM_MEM
+    /* this is used only when IPC RPMessage is enabled, else this is not used */
+    .bss.ipc_vring_mem   (NOLOAD) : {} > RTOS_NORTOS_IPC_SHM_MEM
+    /* this is used only when Secure IPC is enabled */
+    .bss.sipc_hsm_queue_mem   (NOLOAD) : {} > MAILBOX_HSM
+    .bss.sipc_r5f_queue_mem   (NOLOAD) : {} > MAILBOX_R5F
+}
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB  : ORIGIN = 0x00080000 , LENGTH = 0x00008000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    OCRAM     : ORIGIN = 0x70040000 , LENGTH = 0x40000
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60100000 , LENGTH = 0x80000
+
+
+    /* shared memories that are used by RTOS/NORTOS cores */
+    /* On R5F,
+     * - make sure there is a MPU entry which maps below regions as non-cache
+     */
+    USER_SHM_MEM            : ORIGIN = 0x701D0000, LENGTH = 0x00004000
+    LOG_SHM_MEM             : ORIGIN = 0x701D4000, LENGTH = 0x00004000
+    /* MSS mailbox memory is used as shared memory, we dont use bottom 32*12 bytes, since its used as SW queue by ipc_notify */
+    RTOS_NORTOS_IPC_SHM_MEM : ORIGIN = 0x72000000, LENGTH = 0x3E80
+    MAILBOX_HSM:    ORIGIN = 0x44000000 , LENGTH = 0x000003CE
+    MAILBOX_R5F:    ORIGIN = 0x44000400 , LENGTH = 0x000003CE
+    }

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-cc \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263PX \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263px:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263P4 --package ZCZ_S --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263Px --context r5fss0-0 --part AM263P4 --package ZCZ_S --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263px-cc_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,289 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_C" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-C)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.22.0+3893"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                                 = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                       = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                            = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.rx    = true;
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$used = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].manualStartAddress  = 0x60100000;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].$suggestSolution                = "PRU-ICSS";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0]["PRU-ICSS"].PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2022-23 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263Px"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263px-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;MCU-PLUS-SDK-AM263PX"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263Px"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263PX
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263px"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263P4 --package ZCZ_C
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.debug.lib
+                -lboard.am263px.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263px.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263px.r5f.ti-arm-clang.release.lib
+                -lboard.am263px.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263PX_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263px/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/linker.cmd
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/linker.cmd
@@ -1,0 +1,137 @@
+
+/* This is the stack that is used by code running within main()
+ * In case of NORTOS,
+ * - This means all the code outside of ISR uses this stack
+ * In case of FreeRTOS
+ * - This means all the code until vTaskStartScheduler() is called in main()
+ *   uses this stack.
+ * - After vTaskStartScheduler() each task created in FreeRTOS has its own stack
+ */
+--stack_size=16384
+/* This is the heap size for malloc() API in NORTOS and FreeRTOS
+ * This is also the heap used by pvPortMalloc in FreeRTOS
+ */
+--heap_size=32768
+-e_vectors  /* This is the entry of the application, _vector MUST be plabed starting address 0x0 */
+
+/* This is the size of stack when R5 is in IRQ mode
+ * In NORTOS,
+ * - Here interrupt nesting is enabled
+ * - This is the stack used by ISRs registered as type IRQ
+ * In FreeRTOS,
+ * - Here interrupt nesting is enabled
+ * - This is stack that is used initally when a IRQ is received
+ * - But then the mode is switched to SVC mode and SVC stack is used for all user ISR callbacks
+ * - Hence in FreeRTOS, IRQ stack size is less and SVC stack size is more
+ */
+__IRQ_STACK_SIZE = 256;
+/* This is the size of stack when R5 is in IRQ mode
+ * - In both NORTOS and FreeRTOS nesting is disabled for FIQ
+ */
+__FIQ_STACK_SIZE = 256;
+__SVC_STACK_SIZE = 4096; /* This is the size of stack when R5 is in SVC mode */
+__ABORT_STACK_SIZE = 256;  /* This is the size of stack when R5 is in ABORT mode */
+__UNDEFINED_STACK_SIZE = 256;  /* This is the size of stack when R5 is in UNDEF mode */
+
+SECTIONS
+{
+    /* This has the R5F entry point and vector table, this MUST be at 0x0 */
+    .vectors:{} palign(8) > R5F_VECS
+
+    /* This has the R5F boot code until MPU is enabled,  this MUST be at a address < 0x80000000
+     * i.e this cannot be placed in DDR
+     */
+    GROUP {
+        .text.hwi: palign(8)
+        .text.cache: palign(8)
+        .text.mpu: palign(8)
+        .text.boot: palign(8)
+        .text:abort: palign(8) /* this helps in loading symbols when using XIP mode */
+    } > OCRAM
+
+    /* This is rest of code. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .text:   {} palign(8)   /* This is where code resides */
+        .rodata: {} palign(8)   /* This is where const's go */
+    } > OCRAM
+
+    /* This is rest of initialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+
+        .data:   {} palign(8)   /* This is where initialized globals and static go */
+    } > OCRAM
+
+    /* This is rest of uninitialized data. This can be placed in DDR if DDR is available and needed */
+    GROUP {
+        .bss:    {} palign(8)   /* This is where uninitialized globals go */
+        RUN_START(__BSS_START)
+        RUN_END(__BSS_END)
+        .sysmem: {} palign(8)   /* This is where the malloc heap goes */
+        .stack:  {} palign(8)   /* This is where the main() stack goes */
+    } > OCRAM
+
+    /* This is where the stacks for different R5F modes go */
+    GROUP {
+        .irqstack: {. = . + __IRQ_STACK_SIZE;} align(8)
+        RUN_START(__IRQ_STACK_START)
+        RUN_END(__IRQ_STACK_END)
+        .fiqstack: {. = . + __FIQ_STACK_SIZE;} align(8)
+        RUN_START(__FIQ_STACK_START)
+        RUN_END(__FIQ_STACK_END)
+        .svcstack: {. = . + __SVC_STACK_SIZE;} align(8)
+        RUN_START(__SVC_STACK_START)
+        RUN_END(__SVC_STACK_END)
+        .abortstack: {. = . + __ABORT_STACK_SIZE;} align(8)
+        RUN_START(__ABORT_STACK_START)
+        RUN_END(__ABORT_STACK_END)
+        .undefinedstack: {. = . + __UNDEFINED_STACK_SIZE;} align(8)
+        RUN_START(__UNDEFINED_STACK_START)
+        RUN_END(__UNDEFINED_STACK_END)
+    } > OCRAM
+
+    /* Sections needed for C++ projects */
+    GROUP {
+        .ARM.exidx:  {} palign(8)   /* Needed for C++ exception handling */
+        .init_array: {} palign(8)   /* Contains function pointers called before main */
+        .fini_array: {} palign(8)   /* Contains function pointers called after main */
+    } > OCRAM
+
+    /* General purpose user shared memory, used in some examples */
+    .bss.user_shared_mem (NOLOAD) : {} > USER_SHM_MEM
+    /* this is used when Debug log's to shared memory are enabled, else this is not used */
+    .bss.log_shared_mem  (NOLOAD) : {} > LOG_SHM_MEM
+    /* this is used only when IPC RPMessage is enabled, else this is not used */
+    .bss.ipc_vring_mem   (NOLOAD) : {} > RTOS_NORTOS_IPC_SHM_MEM
+    /* this is used only when Secure IPC is enabled */
+    .bss.sipc_hsm_queue_mem   (NOLOAD) : {} > MAILBOX_HSM
+    .bss.sipc_r5f_queue_mem   (NOLOAD) : {} > MAILBOX_R5F
+}
+
+MEMORY
+{
+    R5F_VECS  : ORIGIN = 0x00000000 , LENGTH = 0x00000040
+    R5F_TCMA  : ORIGIN = 0x00000040 , LENGTH = 0x00007FC0
+    R5F_TCMB  : ORIGIN = 0x00080000 , LENGTH = 0x00008000
+
+    /* when using multi-core application's i.e more than one R5F/M4F active, make sure
+     * this memory does not overlap with other R5F's
+     */
+    OCRAM     : ORIGIN = 0x70040000 , LENGTH = 0x40000
+
+    /* This section can be used to put XIP section of the application in flash, make sure this does not overlap with
+     * other CPUs. Also make sure to add a MPU entry for this section and mark it as cached and code executable
+     */
+    FLASH     : ORIGIN = 0x60100000 , LENGTH = 0x80000
+
+
+    /* shared memories that are used by RTOS/NORTOS cores */
+    /* On R5F,
+     * - make sure there is a MPU entry which maps below regions as non-cache
+     */
+    USER_SHM_MEM            : ORIGIN = 0x701D0000, LENGTH = 0x00004000
+    LOG_SHM_MEM             : ORIGIN = 0x701D4000, LENGTH = 0x00004000
+    /* MSS mailbox memory is used as shared memory, we dont use bottom 32*12 bytes, since its used as SW queue by ipc_notify */
+    RTOS_NORTOS_IPC_SHM_MEM : ORIGIN = 0x72000000, LENGTH = 0x3E80
+    MAILBOX_HSM:    ORIGIN = 0x44000000 , LENGTH = 0x000003CE
+    MAILBOX_R5F:    ORIGIN = 0x44000400 , LENGTH = 0x000003CE
+    }

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263px/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263px-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263PX \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263px.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263px:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263px:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263px:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263px:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263P4 --package ZCZ_C --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263Px --context r5fss0-0 --part AM263P4 --package ZCZ_C --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263px:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263px-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,295 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @versions {"tool":"1.23.0+4000"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg         = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+const output_xbar     = scripting.addModule("/xbar/output_xbar/output_xbar", {}, false);
+const output_xbar1    = output_xbar.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                                                              = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name                                    = "CONFIG_PRU_ICSS_IO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO.create(1);
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].$name                         = "CONFIG_PRU_ICSS_GPIO0";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.slewRate = "high";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.$used    = true;
+
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+debug_log.uartLog.child.$name      = "drivers_uart_v2_uart_v2_template0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;
+
+output_xbar1.$name                         = "CONFIG_OUTPUT_XBAR0";
+output_xbar1.xbarOutput                    = ["EPWM0_TRIPOUT"];
+output_xbar1.OUTPUTXBAR.$assign            = "OUTPUTXBAR0";
+output_xbar1.OUTPUTXBAR.OUTPUTXBAR.$assign = "QSPI_CSn1";
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.$suggestSolution                = "ICSSM";
+pruicss1.AdditionalICSSSettings[0].PruGPIO[0].ICSSM.PR0_PRU0_GPIO1.$suggestSolution = "PR0_PRU0_GPIO1";

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2022 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263x-cc_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-cc
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263x --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.debug.lib
+                -lboard.am263x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.release.lib
+                -lboard.am263x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-cc \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263x --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263x_beta --context r5fss0-0 --part AM263x --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263x-cc_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,273 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM263x_beta" --package "ZCZ" --part "AM263x" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.18.0+3266"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+const section12       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+debug_log.enableUartLog            = true;
+debug_log.enableSharedMemLog       = true;
+debug_log.enableSharedMemLogReader = true;
+debug_log.uartLog.$name            = "CONFIG_UART0";
+debug_log.uartLog.UART.$assign     = "UART0";
+debug_log.uartLog.UART.RXD.$assign = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$assign = "UART0_TXD";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x80000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name        = "CONFIG_MPU_REGION4";
+mpu_armv75.size         = 14;
+mpu_armv75.baseAddr     = 0x50D00000;
+mpu_armv75.allowExecute = false;
+mpu_armv75.attributes   = "Device";
+
+mpu_armv76.$name        = "CONFIG_MPU_REGION5";
+mpu_armv76.size         = 14;
+mpu_armv76.allowExecute = false;
+mpu_armv76.attributes   = "NonCached";
+mpu_armv76.baseAddr     = 0x72000000;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                                = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(11);
+region1.memory_region[0].type                = "TCMA";
+region1.memory_region[0].$name               = "R5F_VECS";
+region1.memory_region[0].size                = 0x40;
+region1.memory_region[0].auto                = false;
+region1.memory_region[1].type                = "TCMA";
+region1.memory_region[1].$name               = "R5F_TCMA";
+region1.memory_region[1].size                = 0x7FC0;
+region1.memory_region[2].type                = "TCMB";
+region1.memory_region[2].size                = 0x8000;
+region1.memory_region[2].$name               = "R5F_TCMB";
+region1.memory_region[3].$name               = "SBL";
+region1.memory_region[3].auto                = false;
+region1.memory_region[3].size                = 0x40000;
+region1.memory_region[4].$name               = "OCRAM";
+region1.memory_region[4].auto                = false;
+region1.memory_region[4].manualStartAddress  = 0x70040000;
+region1.memory_region[4].size                = 0x40000;
+region1.memory_region[5].type                = "FLASH";
+region1.memory_region[5].auto                = false;
+region1.memory_region[5].size                = 0x80000;
+region1.memory_region[5].$name               = "FLASH";
+region1.memory_region[6].$name               = "USER_SHM_MEM";
+region1.memory_region[6].auto                = false;
+region1.memory_region[6].manualStartAddress  = 0x701D0000;
+region1.memory_region[6].size                = 0x4000;
+region1.memory_region[6].isShared            = true;
+region1.memory_region[6].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].$name               = "LOG_SHM_MEM";
+region1.memory_region[7].auto                = false;
+region1.memory_region[7].manualStartAddress  = 0x701D4000;
+region1.memory_region[7].size                = 0x4000;
+region1.memory_region[7].isShared            = true;
+region1.memory_region[7].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].type                = "CUSTOM";
+region1.memory_region[8].$name               = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].auto                = false;
+region1.memory_region[8].manualStartAddress  = 0x72000000;
+region1.memory_region[8].size                = 0x3E80;
+region1.memory_region[8].isShared            = true;
+region1.memory_region[8].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[9].type                = "CUSTOM";
+region1.memory_region[9].$name               = "MAILBOX_HSM";
+region1.memory_region[9].auto                = false;
+region1.memory_region[9].manualStartAddress  = 0x44000000;
+region1.memory_region[9].size                = 0x3CE;
+region1.memory_region[9].isShared            = true;
+region1.memory_region[9].shared_cores        = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[10].type               = "CUSTOM";
+region1.memory_region[10].$name              = "MAILBOX_R5F";
+region1.memory_region[10].auto               = false;
+region1.memory_region[10].manualStartAddress = 0x44000400;
+region1.memory_region[10].size               = 0x3CE;
+region1.memory_region[10].isShared           = true;
+region1.memory_region[10].shared_cores       = ["r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.$name                        = "Vector Table";
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.load_memory                  = "OCRAM";
+section2.$name                        = "Text Segments";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.load_memory                  = "OCRAM";
+section3.$name                        = "Code and Read-Only Data";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.load_memory                  = "OCRAM";
+section4.$name                        = "Data Segment";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.load_memory                             = "OCRAM";
+section5.$name                                   = "Memory Segments";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[0].palignment            = true;
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.load_memory                              = "OCRAM";
+section6.$name                                    = "Stack Segments";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.load_memory                  = "OCRAM";
+section7.$name                        = "Initialization and Exception Handling";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.load_memory                 = "USER_SHM_MEM";
+section8.type                        = "NOLOAD";
+section8.$name                       = "User Shared Memory";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.$name                       = "Log Shared Memory";
+section9.group                       = false;
+section9.type                        = "NOLOAD";
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.type                        = "NOLOAD";
+section10.$name                       = "IPC Shared Memory";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.load_memory                 = "MAILBOX_HSM";
+section11.type                        = "NOLOAD";
+section11.$name                       = "SIPC HSM Queue Memory";
+section11.group                       = false;
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.sipc_hsm_queue_mem";
+section11.output_section[0].alignment = 0;
+
+section12.load_memory                 = "MAILBOX_R5F";
+section12.$name                       = "SIPC R5F Queue Memory";
+section12.group                       = false;
+section12.type                        = "NOLOAD";
+section12.output_section.create(1);
+section12.output_section[0].$name     = ".bss.sipc_secure_host_queue_mem";
+section12.output_section[0].alignment = 0;

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018-2022 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM263x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am263x-lp_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM263X"
+        configurations="
+            Release,
+            Debug,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM263x"
+        deviceCore="Cortex_R5_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-lp
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM263X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am263x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part AM263x --package ZCZ
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.debug.lib
+                -lboard.am263x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am263x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am263x.r5f.ti-arm-clang.release.lib
+                -lboard.am263x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM263X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="${OPEN_PRU_PATH}/docs/api_guide_am263x/EXAMPLES_PRU_EMPTY.html"
+                openOnCreation="false" excludeFromBuild="false" targetName="README.html" action="link">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,369 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_NAME_MCELF:=pru_add_pru_io.$(PROFILE).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=pru_add_pru_io.$(PROFILE).mcelf.hs
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am263x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am263x-lp \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM263X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am263x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am263x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am263x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am263x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am263x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+	$(RM) \*.mcelf
+	$(RM) \*.mcelf_xip
+	$(RM) \*.mcelf-enc
+	$(RM) \*.mcelf.hs
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+	$(RM) *.mcelf
+	$(RM) *.mcelf_xip
+	$(RM) *.mcelf-enc
+	$(RM) *.mcelf.hs
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part AM263x --package ZCZ --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM263x_beta --context r5fss0-0 --part AM263x --package ZCZ --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ Done !!!
+	@echo  Boot MulticoreELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) ...
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTNAME) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+	@echo  Boot MulticoreELF ELF image: $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+$(BOOTIMAGE_NAME_HS): $(BOOTIMAGE_NAME)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSAPSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,141 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+BOOTIMAGE_NAME_MCELF:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf
+BOOTIMAGE_NAME_MCELF_HS:=$(BOOTIMAGE_PATH)/$(OUTNAME).mcelf.hs
+BOOTIMAGE_NAME_HS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=$(BOOTIMAGE_PATH)/pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+TARGETS += $(BOOTIMAGE_NAME_MCELF)
+TARGETS += $(BOOTIMAGE_NAME_MCELF_HS)
+ifeq ($(DEVICE_TYPE), HS)
+   TARGETS += $(BOOTIMAGE_NAME_HS)
+endif
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_r5fss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-1 = 1
+BOOTIMAGE_CORE_ID_r5fss1-0 = 2
+BOOTIMAGE_CORE_ID_r5fss1-1 = 3
+SBL_RUN_ADDRESS=0x70002000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/mcu_appimage_x509_cert_gen.py
+MCELF_IMAGE_GEN = $(MCU_PLUS_SDK_PATH)/tools/boot/multicore-elf/genimage.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+
+	@echo  Boot multi-core ELF image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME_MCELF) ...
+
+	$(PYTHON) $(MCELF_IMAGE_GEN) --core-img=$(BOOTIMAGE_CORE_ID_r5fss0-0):$(OUTFILE) --output=$(BOOTIMAGE_NAME_MCELF) --merge-segments=$(MCELF_MERGE_SEGMENTS_FLAG) --tolerance-limit=$(MCELF_MERGE_SEGMENTS_TOLERANCE_LIMIT) --ignore-context=$(MCELF_IGNORE_CONTEXT_FLAG) --xip=$(MCELF_XIP_RANGE) --xlat=$(MCELF_ADDR_TRANSLATION_PATH) --max-segment-size=$(MCELF_MAX_SEGMENT_SIZE)
+
+	@echo  Boot multi-core ELF image: $(BOOTIMAGE_NAME_MCELF) Done !!!
+	@echo  .
+
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) Done !!!
+	@echo  .
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+else
+	@echo Boot image signing: Encryption is disabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+endif
+else
+ifeq ($(RSASSAPSS_ENABLED),no)
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --output $(BOOTIMAGE_NAME_MCELF_HS)
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+else
+	@echo Boot image signing: Encryption is enabled. RSASSA-PSS is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME)-enc
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME_MCELF) --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --kd-salt $(KD_SALT) --sign_key_id $(APP_SIGNING_KEY_KEYRING_ID) --enc_key_id $(APP_ENCRYPTION_KEY_KEYRING_ID) --hash_algo $(APP_SIGNING_HASH_ALGO) --pss_saltlen $(APP_SIGNING_SALT_LENGTH) --output $(BOOTIMAGE_NAME_MCELF_HS) --rsassa_pss
+	$(RM) $(BOOTIMAGE_NAME_MCELF)-enc
+endif
+endif
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  Boot image: am263x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_MCELF_HS) Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am263x-lp_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/example.syscfg
@@ -1,0 +1,253 @@
+/**
+ * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
+ * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
+ * @cliArgs --device "AM64x" --package "ALV" --part "Default" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01"
+ * @versions {"tool":"1.17.0+3128"}
+ */
+
+/**
+ * Import the modules used in this configuration.
+ */
+const pruicss         = scripting.addModule("/drivers/pruicss/pruicss", {}, false);
+const pruicss1        = pruicss.addInstance();
+const debug_log       = scripting.addModule("/kernel/dpl/debug_log");
+const dpl_cfg = scripting.addModule("/kernel/dpl/dpl_cfg");
+const mpu_armv7       = scripting.addModule("/kernel/dpl/mpu_armv7", {}, false);
+const mpu_armv71      = mpu_armv7.addInstance();
+const mpu_armv72      = mpu_armv7.addInstance();
+const mpu_armv73      = mpu_armv7.addInstance();
+const mpu_armv74      = mpu_armv7.addInstance();
+const mpu_armv75      = mpu_armv7.addInstance();
+const mpu_armv76      = mpu_armv7.addInstance();
+const default_linker  = scripting.addModule("/memory_configurator/default_linker", {}, false);
+const default_linker1 = default_linker.addInstance();
+const general         = scripting.addModule("/memory_configurator/general", {}, false);
+const general1        = general.addInstance();
+const region          = scripting.addModule("/memory_configurator/region", {}, false);
+const region1         = region.addInstance();
+const section         = scripting.addModule("/memory_configurator/section", {}, false);
+const section1        = section.addInstance();
+const section2        = section.addInstance();
+const section3        = section.addInstance();
+const section4        = section.addInstance();
+const section5        = section.addInstance();
+const section6        = section.addInstance();
+const section7        = section.addInstance();
+const section8        = section.addInstance();
+const section9        = section.addInstance();
+const section10       = section.addInstance();
+const section11       = section.addInstance();
+
+/**
+ * Write custom configuration values to the imported modules.
+ */
+pruicss1.$name                           = "CONFIG_PRU_ICSS0";
+pruicss1.AdditionalICSSSettings[0].$name = "CONFIG_PRU_ICSS_IO0";
+
+debug_log.enableUartLog        = true;
+debug_log.uartLog.$name        = "CONFIG_UART_CONSOLE";
+debug_log.uartLog.UART.$assign = "USART0";
+
+mpu_armv71.$name             = "CONFIG_MPU_REGION0";
+mpu_armv71.size              = 31;
+mpu_armv71.attributes        = "Device";
+mpu_armv71.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv71.allowExecute      = false;
+
+mpu_armv72.$name             = "CONFIG_MPU_REGION1";
+mpu_armv72.size              = 15;
+mpu_armv72.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv73.$name             = "CONFIG_MPU_REGION2";
+mpu_armv73.baseAddr          = 0x41010000;
+mpu_armv73.size              = 15;
+mpu_armv73.accessPermissions = "Supervisor RD+WR, User RD";
+
+mpu_armv74.$name             = "CONFIG_MPU_REGION3";
+mpu_armv74.accessPermissions = "Supervisor RD+WR, User RD";
+mpu_armv74.baseAddr          = 0x70000000;
+mpu_armv74.size              = 21;
+
+mpu_armv75.$name             = "CONFIG_MPU_REGION4";
+mpu_armv75.baseAddr          = 0x60000000;
+mpu_armv75.size              = 28;
+mpu_armv75.accessPermissions = "Supervisor RD, User RD";
+
+mpu_armv76.$name    = "CONFIG_MPU_REGION5";
+mpu_armv76.baseAddr = 0x80000000;
+mpu_armv76.size     = 31;
+
+default_linker1.$name = "memory_configurator_default_linker0";
+
+general1.$name        = "CONFIG_GENERAL0";
+general1.linker.$name = "TIARMCLANG0";
+
+region1.$name                               = "MEMORY_REGION_CONFIGURATION0";
+region1.memory_region.create(9);
+region1.memory_region[0].type               = "TCMA_R5F";
+region1.memory_region[0].$name              = "R5F_VECS";
+region1.memory_region[0].size               = 0x40;
+region1.memory_region[0].auto               = false;
+region1.memory_region[1].type               = "TCMA_R5F";
+region1.memory_region[1].$name              = "R5F_TCMA";
+region1.memory_region[1].size               = 0x7FC0;
+region1.memory_region[2].type               = "TCMB_R5F";
+region1.memory_region[2].$name              = "R5F_TCMB0";
+region1.memory_region[2].size               = 0x8000;
+region1.memory_region[3].$name              = "NON_CACHE_MEM";
+region1.memory_region[3].auto               = false;
+region1.memory_region[3].manualStartAddress = 0x70060000;
+region1.memory_region[3].size               = 0x8000;
+region1.memory_region[4].$name              = "MSRAM";
+region1.memory_region[4].auto               = false;
+region1.memory_region[4].manualStartAddress = 0x70080000;
+region1.memory_region[4].size               = 0x40000;
+region1.memory_region[5].type               = "FLASH";
+region1.memory_region[5].$name              = "FLASH";
+region1.memory_region[5].auto               = false;
+region1.memory_region[5].manualStartAddress = 0x60100000;
+region1.memory_region[5].size               = 0x80000;
+region1.memory_region[6].$name              = "USER_SHM_MEM";
+region1.memory_region[6].auto               = false;
+region1.memory_region[6].manualStartAddress = 0x701D0000;
+region1.memory_region[6].size               = 0x80;
+region1.memory_region[6].isShared           = true;
+region1.memory_region[6].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[7].auto               = false;
+region1.memory_region[7].manualStartAddress = 0x701D0080;
+region1.memory_region[7].size               = 0x3F80;
+region1.memory_region[7].$name              = "LOG_SHM_MEM";
+region1.memory_region[7].isShared           = true;
+region1.memory_region[7].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+region1.memory_region[8].auto               = false;
+region1.memory_region[8].manualStartAddress = 0x701D4000;
+region1.memory_region[8].size               = 0xC000;
+region1.memory_region[8].$name              = "RTOS_NORTOS_IPC_SHM_MEM";
+region1.memory_region[8].isShared           = true;
+region1.memory_region[8].shared_cores       = ["a53ss0-0","a53ss0-1","m4fss0-0","r5fss0-1","r5fss1-0","r5fss1-1"];
+
+section1.$name                        = "Vector Table";
+section1.load_memory                  = "R5F_VECS";
+section1.group                        = false;
+section1.output_section.create(1);
+section1.output_section[0].$name      = ".vectors";
+section1.output_section[0].palignment = true;
+
+section2.$name                        = "Text Segments";
+section2.load_memory                  = "MSRAM";
+section2.output_section.create(5);
+section2.output_section[0].$name      = ".text.hwi";
+section2.output_section[0].palignment = true;
+section2.output_section[1].$name      = ".text.cache";
+section2.output_section[1].palignment = true;
+section2.output_section[2].$name      = ".text.mpu";
+section2.output_section[2].palignment = true;
+section2.output_section[3].$name      = ".text.boot";
+section2.output_section[3].palignment = true;
+section2.output_section[4].$name      = ".text:abort";
+section2.output_section[4].palignment = true;
+
+section3.$name                        = "Code and Read-Only Data";
+section3.load_memory                  = "MSRAM";
+section3.output_section.create(2);
+section3.output_section[0].$name      = ".text";
+section3.output_section[0].palignment = true;
+section3.output_section[1].$name      = ".rodata";
+section3.output_section[1].palignment = true;
+
+section4.$name                        = "Data Segment";
+section4.load_memory                  = "MSRAM";
+section4.output_section.create(1);
+section4.output_section[0].$name      = ".data";
+section4.output_section[0].palignment = true;
+
+section5.$name                                   = "Memory Segments";
+section5.load_memory                             = "MSRAM";
+section5.output_section.create(3);
+section5.output_section[0].$name                 = ".bss";
+section5.output_section[0].palignment            = true;
+section5.output_section[0].output_sections_start = "__BSS_START";
+section5.output_section[0].output_sections_end   = "__BSS_END";
+section5.output_section[1].$name                 = ".sysmem";
+section5.output_section[1].palignment            = true;
+section5.output_section[2].$name                 = ".stack";
+section5.output_section[2].palignment            = true;
+
+section6.$name                                    = "Stack Segments";
+section6.load_memory                              = "MSRAM";
+section6.output_section.create(5);
+section6.output_section[0].$name                  = ".irqstack";
+section6.output_section[0].output_sections_start  = "__IRQ_STACK_START";
+section6.output_section[0].output_sections_end    = "__IRQ_STACK_END";
+section6.output_section[0].input_section.create(1);
+section6.output_section[0].input_section[0].$name = ". = . + __IRQ_STACK_SIZE;";
+section6.output_section[1].$name                  = ".fiqstack";
+section6.output_section[1].output_sections_start  = "__FIQ_STACK_START";
+section6.output_section[1].output_sections_end    = "__FIQ_STACK_END";
+section6.output_section[1].input_section.create(1);
+section6.output_section[1].input_section[0].$name = ". = . + __FIQ_STACK_SIZE;";
+section6.output_section[2].$name                  = ".svcstack";
+section6.output_section[2].output_sections_start  = "__SVC_STACK_START";
+section6.output_section[2].output_sections_end    = "__SVC_STACK_END";
+section6.output_section[2].input_section.create(1);
+section6.output_section[2].input_section[0].$name = ". = . + __SVC_STACK_SIZE;";
+section6.output_section[3].$name                  = ".abortstack";
+section6.output_section[3].output_sections_start  = "__ABORT_STACK_START";
+section6.output_section[3].output_sections_end    = "__ABORT_STACK_END";
+section6.output_section[3].input_section.create(1);
+section6.output_section[3].input_section[0].$name = ". = . + __ABORT_STACK_SIZE;";
+section6.output_section[4].$name                  = ".undefinedstack";
+section6.output_section[4].output_sections_start  = "__UNDEFINED_STACK_START";
+section6.output_section[4].output_sections_end    = "__UNDEFINED_STACK_END";
+section6.output_section[4].input_section.create(1);
+section6.output_section[4].input_section[0].$name = ". = . + __UNDEFINED_STACK_SIZE;";
+
+section7.$name                        = "Initialization and Exception Handling";
+section7.load_memory                  = "MSRAM";
+section7.output_section.create(3);
+section7.output_section[0].$name      = ".ARM.exidx";
+section7.output_section[0].palignment = true;
+section7.output_section[1].$name      = ".init_array";
+section7.output_section[1].palignment = true;
+section7.output_section[2].$name      = ".fini_array";
+section7.output_section[2].palignment = true;
+
+section8.$name                       = "User Shared Memory";
+section8.type                        = "NOLOAD";
+section8.load_memory                 = "USER_SHM_MEM";
+section8.group                       = false;
+section8.output_section.create(1);
+section8.output_section[0].$name     = ".bss.user_shared_mem";
+section8.output_section[0].alignment = 0;
+
+section9.$name                       = "Log Shared Memory";
+section9.load_memory                 = "LOG_SHM_MEM";
+section9.type                        = "NOLOAD";
+section9.group                       = false;
+section9.output_section.create(1);
+section9.output_section[0].$name     = ".bss.log_shared_mem";
+section9.output_section[0].alignment = 0;
+
+section10.$name                       = "IPC Shared Memory";
+section10.type                        = "NOLOAD";
+section10.load_memory                 = "RTOS_NORTOS_IPC_SHM_MEM";
+section10.group                       = false;
+section10.output_section.create(1);
+section10.output_section[0].$name     = ".bss.ipc_vring_mem";
+section10.output_section[0].alignment = 0;
+
+section11.$name                       = "Non Cacheable Memory";
+section11.load_memory                 = "NON_CACHE_MEM";
+section11.group                       = false;
+section11.type                        = "NOLOAD";
+section11.output_section.create(1);
+section11.output_section[0].$name     = ".bss.nocache";
+section11.output_section[0].alignment = 0;
+
+/**
+ * Pinmux solution for unlocked pins/peripherals. This ensures that minor changes to the automatic solver in a future
+ * version of the tool will not impact the pinmux you originally saw.  These lines can be completely deleted in order to
+ * re-solve from scratch.
+ */
+debug_log.uartLog.UART.RXD.$suggestSolution = "UART0_RXD";
+debug_log.uartLog.UART.TXD.$suggestSolution = "UART0_TXD";

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/main.c
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/main.c
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_board_config.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAIN_TASK_PRI  (configMAX_PRIORITIES-1)
+
+#define MAIN_TASK_SIZE (16384U/sizeof(configSTACK_DEPTH_TYPE))
+StackType_t gMainTaskStack[MAIN_TASK_SIZE] __attribute__((aligned(32)));
+
+StaticTask_t gMainTaskObj;
+TaskHandle_t gMainTask;
+
+void pru_io_pru_add_main(void *args);
+
+void freertos_main(void *args)
+{
+    pru_io_pru_add_main(NULL);
+
+    vTaskDelete(NULL);
+}
+
+
+int main(void)
+{
+    /* init SOC specific modules */
+    System_init();
+    Board_init();
+
+    /* This task is created at highest priority, it should create more tasks and then delete itself */
+    gMainTask = xTaskCreateStatic( freertos_main,   /* Pointer to the function that implements the task. */
+                                  "freertos_main", /* Text name for the task.  This is to facilitate debugging only. */
+                                  MAIN_TASK_SIZE,  /* Stack depth in units of StackType_t typically uint32_t on 32b CPUs */
+                                  NULL,            /* We are not using the task parameter. */
+                                  MAIN_TASK_PRI,   /* task priority, 0 is lowest priority, configMAX_PRIORITIES-1 is highest */
+                                  gMainTaskStack,  /* pointer to stack base */
+                                  &gMainTaskObj ); /* pointer to statically allocated task object memory */
+    configASSERT(gMainTask != NULL);
+
+    /* Start the scheduler to start the tasks executing. */
+    vTaskStartScheduler();
+
+    /* The following line should never be reached because vTaskStartScheduler()
+    will only return if there was not enough FreeRTOS heap memory available to
+    create the Idle and (if configured) Timer tasks.  Heap management, and
+    techniques for trapping heap exhaustion, are described in the book text. */
+    DebugP_assertNoLog(0);
+
+    return 0;
+}

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/example.projectspec
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="ARM"
+                deviceId="Cortex R.AM64x"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="Empty Pru Io"
+        name = "pru_add_pru_io_am64x-evm_r5fss0-0_freertos_ti-arm-clang"
+        products="sysconfig;com.ti.OPEN_PRU;com.ti.MCU_PLUS_SDK_AM64X"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TICLANG"
+        cgtVersion="4.0.0"
+        device="Cortex R.AM64x"
+        deviceCore="MAIN_PULSAR_Cortex_R5_0_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include/c
+            -I${MCU_PLUS_SDK_PATH}/source
+            -I${OPEN_PRU_PATH}/source
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F
+            -I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am64x/r5f
+            -I${MCU_PLUS_SDK_PATH}/source/pru_io/driver
+            -I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm
+            -mcpu=cortex-r5
+            -mfloat-abi=hard
+            -mfpu=vfpv3-d16
+            -mthumb
+            -Wall
+            -Werror
+            -g
+            -Wno-gnu-variable-sized-type-not-at-end
+            -Wno-unused-function
+            -DSOC_AM64X
+        "
+        linkerBuildOptions="
+            -i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib
+            -i${MCU_PLUS_SDK_PATH}/source/drivers/lib
+            -i${MCU_PLUS_SDK_PATH}/source/board/lib
+            -i${MCU_PLUS_SDK_PATH}/source/pru_io/lib
+            -i${CG_TOOL_ROOT}/lib
+            -m=pru_add_pru_io.${ConfigName}.map
+            --diag_suppress=10063
+            --ram_model
+            --reread_libs
+        "
+
+        postBuildStep="$(MAKE) -C ${CCS_PROJECT_DIR} -f makefile_ccs_bootimage_gen OUTNAME=${BuildArtifactFileBaseName} PROFILE=${ConfigName} MCU_PLUS_SDK_PATH=${MCU_PLUS_SDK_PATH} OPEN_PRU_PATH=${OPEN_PRU_PATH} CG_TOOL_ROOT=${CG_TOOL_ROOT} CCS_INSTALL_DIR=${CCS_INSTALL_DIR} CCS_IDE_MODE=${CCS_IDE_MODE} DEVICE=am64x"
+
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="
+            --context r5fss0-0 --part Default --package ALV
+        "
+
+        description="A Empty Pru Io FREERTOS project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+                -lfreertos.am64x.r5f.ti-arm-clang.debug.lib
+                -ldrivers.am64x.r5f.ti-arm-clang.debug.lib
+                -lboard.am64x.r5f.ti-arm-clang.debug.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+                -Os
+            "
+            linkerBuildOptions="
+                -lfreertos.am64x.r5f.ti-arm-clang.release.lib
+                -ldrivers.am64x.r5f.ti-arm-clang.release.lib
+                -lboard.am64x.r5f.ti-arm-clang.release.lib
+                -llibc.a
+                -llibsysbm.a
+            "
+        ></configuration>
+        <pathVariable name="MCU_PLUS_SDK_PATH" path="${COM_TI_MCU_PLUS_SDK_AM64X_INSTALL_DIR}" scope="project" />
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../../../pru_add.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="../example.syscfg" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="syscfg_c.rov.xs" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="makefile_ccs_bootimage_gen" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile
@@ -1,0 +1,341 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+
+CG_TOOL_ROOT=$(CGT_TI_ARM_CLANG_PATH)
+
+CC=$(CG_TOOL_ROOT)/bin/tiarmclang
+LNK=$(CG_TOOL_ROOT)/bin/tiarmclang
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+COV=$(CG_TOOL_ROOT)/bin/tiarmcov
+PROFDATA=$(CG_TOOL_ROOT)/bin/tiarmprofdata
+COVERAGE_PATH=$(abspath .)
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+PROFILE?=release
+ConfigName:=$(PROFILE)
+
+OUTNAME:=pru_add_pru_io.$(PROFILE).out
+
+BOOTIMAGE_PATH=$(abspath .)
+BOOTIMAGE_NAME:=pru_add_pru_io.$(PROFILE).appimage
+BOOTIMAGE_NAME_XIP:=pru_add_pru_io.$(PROFILE).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=pru_add_pru_io.$(PROFILE).appimage.signed
+BOOTIMAGE_RPRC_NAME:=pru_add_pru_io.$(PROFILE).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=pru_add_pru_io.$(PROFILE).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=pru_add_pru_io.$(PROFILE).rprc_tmp
+BOOTIMAGE_NAME_HS:=pru_add_pru_io.$(PROFILE).appimage.hs
+BOOTIMAGE_NAME_HS_FS:=pru_add_pru_io.$(PROFILE).appimage.hs_fs
+TARGETS := $(BOOTIMAGE_NAME)
+
+
+FILES_common := \
+	main.c \
+	pru_add.c \
+	ti_drivers_config.c \
+	ti_drivers_open_close.c \
+	ti_board_config.c \
+	ti_board_open_close.c \
+	ti_dpl_config.c \
+	ti_pinmux_config.c \
+	ti_power_clock_config.c \
+
+FILES_PATH_common = \
+	.. \
+	../../.. \
+	generated \
+
+INCLUDES_common := \
+	-I${CG_TOOL_ROOT}/include/c \
+	-I${MCU_PLUS_SDK_PATH}/source \
+	-I${OPEN_PRU_PATH}/source \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/FreeRTOS-Kernel/include \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/portable/TI_ARM_CLANG/ARM_CR5F \
+	-I${MCU_PLUS_SDK_PATH}/source/kernel/freertos/config/am64x/r5f \
+	-I${MCU_PLUS_SDK_PATH}/source/pru_io/driver \
+	-I${OPEN_PRU_PATH}/academy/getting_started_labs/c_code/solution/firmware/am64x-evm \
+	-Igenerated \
+
+DEFINES_common := \
+	-DSOC_AM64X \
+
+CFLAGS_common := \
+	-mcpu=cortex-r5 \
+	-mfloat-abi=hard \
+	-mfpu=vfpv3-d16 \
+	-mthumb \
+	-Wall \
+	-Werror \
+	-g \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-unused-function \
+
+CFLAGS_cpp_common := \
+	-Wno-c99-designator \
+	-Wno-extern-c-compat \
+	-Wno-c++11-narrowing \
+	-Wno-reorder-init-list \
+	-Wno-register \
+	-Wno-writable-strings \
+	-Wno-enum-compare \
+	-Wno-reserved-user-defined-literal \
+	-Wno-unused-const-variable \
+	-Wno-vla-cxx-extension \
+	-x c++ \
+
+CFLAGS_debug := \
+	-D_DEBUG_=1 \
+
+CFLAGS_release := \
+	-Os \
+
+LNK_FILES_common = \
+	generated/linker.cmd \
+
+LIBS_PATH_common = \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/board/lib \
+	-Wl,-i${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	-Wl,-i${CG_TOOL_ROOT}/lib \
+
+LIBS_common = \
+	-lfreertos.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-ldrivers.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-lboard.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	-llibc.a \
+	-llibsysbm.a \
+
+LFLAGS_common = \
+	-Wl,--diag_suppress=10063 \
+	-Wl,--ram_model \
+	-Wl,--reread_libs \
+
+
+LIBS_NAME = \
+	freertos.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	drivers.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	board.am64x.r5f.ti-arm-clang.${ConfigName}.lib \
+	libc.a \
+	libsysbm.a \
+
+LIBS_PATH_NAME = \
+	${MCU_PLUS_SDK_PATH}/source/kernel/freertos/lib \
+	${MCU_PLUS_SDK_PATH}/source/drivers/lib \
+	${MCU_PLUS_SDK_PATH}/source/board/lib \
+	${MCU_PLUS_SDK_PATH}/source/pru_io/lib \
+	${CG_TOOL_ROOT}/lib \
+
+FILES := $(FILES_common) $(FILES_$(PROFILE))
+ASMFILES := $(ASMFILES_common) $(ASMFILES_$(PROFILE))
+FILES_PATH := $(FILES_PATH_common) $(FILES_PATH_$(PROFILE))
+CFLAGS := $(CFLAGS_common) $(CFLAGS_$(PROFILE))
+ifeq ($(INSTRUMENTATION_MODE), yes)
+CFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+DEFINES := $(DEFINES_common) $(DEFINES_$(PROFILE))
+INCLUDES := $(INCLUDES_common) $(INCLUDE_$(PROFILE))
+LIBS := $(LIBS_common) $(LIBS_$(PROFILE))
+LIBS_PATH := $(LIBS_PATH_common) $(LIBS_PATH_$(PROFILE))
+LFLAGS := $(LFLAGS_common) $(LFLAGS_$(PROFILE))
+LNKOPTFLAGS := $(LNKOPTFLAGS_common) $(LNKOPTFLAGS_$(PROFILE))
+LNK_FILES := $(LNK_FILES_common) $(LNK_FILES_$(PROFILE))
+
+OBJDIR := obj/$(PROFILE)/
+OBJS := $(FILES:%.c=%.obj)
+OBJS += $(ASMFILES:%.S=%.obj)
+DEPS := $(FILES:%.c=%.d)
+
+vpath %.obj $(OBJDIR)
+vpath %.c $(FILES_PATH)
+vpath %.S $(FILES_PATH)
+vpath %.lib $(LIBS_PATH_NAME)
+vpath %.a $(LIBS_PATH_NAME)
+
+$(OBJDIR)/%.obj %.obj: %.c
+	@echo  Compiling: am64x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME): $<
+	$(CC) -c $(CFLAGS) $(INCLUDES) $(DEFINES) -MMD -o $(OBJDIR)/$@ $<
+
+$(OBJDIR)/%.obj %.obj: %.S
+	@echo  Compiling: am64x:r5fss0-0:freertos:ti-arm-clang $(LIBNAME): $<
+	$(CC) -c $(CFLAGS) -o $(OBJDIR)/$@ $<
+
+all: $(TARGETS)
+
+SYSCFG_GEN_FILES=generated/ti_drivers_config.c generated/ti_drivers_config.h
+SYSCFG_GEN_FILES+=generated/ti_drivers_open_close.c generated/ti_drivers_open_close.h
+SYSCFG_GEN_FILES+=generated/ti_dpl_config.c generated/ti_dpl_config.h
+SYSCFG_GEN_FILES+=generated/ti_pinmux_config.c generated/ti_power_clock_config.c
+SYSCFG_GEN_FILES+=generated/ti_board_config.c generated/ti_board_config.h
+SYSCFG_GEN_FILES+=generated/ti_board_open_close.c generated/ti_board_open_close.h
+
+SYSTEM_FLAG ?= false
+
+ifeq ($(SYSTEM_FLAG), false)
+	SYSTEM_COMMAND := syscfg $(SYSCFG_GEN_FILES) $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+else
+	SYSTEM_COMMAND := $(OBJS) $(LNK_FILES) $(LIBS_NAME)
+endif
+
+$(OUTNAME):  $(SYSTEM_COMMAND)
+	@echo  .
+	@echo  Linking: am64x:r5fss0-0:freertos:ti-arm-clang $@ ...
+	$(LNK) $(LNKOPTFLAGS) $(LFLAGS) $(LIBS_PATH) -Wl,-m=$(basename $@).map -o $@ $(addprefix $(OBJDIR), $(OBJS)) $(LIBS) $(LNK_FILES)
+	@echo  Linking: am64x:r5fss0-0:freertos:ti-arm-clang $@ Done !!!
+	@echo  .
+
+clean:
+	@echo  Cleaning: am64x:r5fss0-0:freertos:ti-arm-clang $(OUTNAME) ...
+	$(RMDIR) $(OBJDIR)
+	$(RM) $(OUTNAME)
+	$(RM) $(BOOTIMAGE_NAME)
+	$(RM) $(BOOTIMAGE_NAME_XIP)
+	$(RM) $(BOOTIMAGE_NAME_SIGNED)
+	$(RM) $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_XIP)
+	$(RMDIR) generated/
+
+scrub:
+	@echo  Scrubing: am64x:r5fss0-0:freertos:ti-arm-clang pru_add_pru_io ...
+	$(RMDIR) obj
+ifeq ($(OS),Windows_NT)
+	$(RM) \*.out
+	$(RM) \*.map
+	$(RM) \*.appimage*
+	$(RM) \*.rprc*
+	$(RM) \*.tiimage*
+	$(RM) \*.bin
+else
+	$(RM) *.out
+	$(RM) *.map
+	$(RM) *.appimage*
+	$(RM) *.rprc*
+	$(RM) *.tiimage*
+	$(RM) *.bin
+endif
+	$(RMDIR) generated
+
+$(OBJS): | $(OBJDIR)
+
+$(OBJDIR):
+	$(MKDIR) $@
+
+
+.NOTPARALLEL:
+
+.INTERMEDIATE: syscfg
+$(SYSCFG_GEN_FILES): syscfg
+
+ifeq ($(SYSTEM_FLAG), false)
+syscfg: ../example.syscfg
+	@echo Generating SysConfig files ...
+	$(SYSCFG_NODE) $(SYSCFG_CLI_PATH)/dist/cli.js --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --context r5fss0-0 --part Default --package ALV --output generated/ ../example.syscfg
+endif
+
+syscfg-gui:
+	$(SYSCFG_NWJS) $(SYSCFG_PATH) --product $(SYSCFG_SDKPRODUCT) --product $(SYSCFG_MCU_PLUS_SDK_PRODUCT) --device AM64x --context r5fss0-0 --part Default --package ALV --output generated/  ../example.syscfg
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CERT_KEY=$(APP_SIGNING_KEY)
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(SYSCFG_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+$(BOOTIMAGE_NAME): $(OUTNAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$@ ...
+ifneq ($(OS),Windows_NT)
+	$(CHMOD) a+x $(XIPGEN_CMD)
+endif
+	$(OUTRPRC_CMD) $(OUTNAME) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE), HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME_HS)
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS) Done !!!
+	@echo  .
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME_HS_FS)
+	$(RM) $(BOOTIMAGE_NAME)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_PATH)/$(BOOTIMAGE_NAME_HS_FS) Done !!!
+	@echo  .
+endif
+
+
+
+.PHONY: coverage
+coverage:
+	@echo Creating Coverage Report for pru_add_pru_io.$(PROFILE) ...
+	$(MKDIR) coverage
+	$(PROFDATA) merge -sparse -obj-file=$(OUTNAME) $(OUTNAME).cnt -o pru_add_pru_io.$(PROFILE).profdata
+	$(COV) show --format=html --show-expansions --show-instantiations --show-branches=count --object=$(OUTNAME) -instr-profile=pru_add_pru_io.$(PROFILE).profdata --output-dir=$(COVERAGE_PATH)/coverage --ignore-filename-regex=build_jenkins
+	$(COV) export --format=text --object=$(OUTNAME) --instr-profile=pru_add_pru_io.$(PROFILE).profdata > coverage/pru_add_pru_io.$(PROFILE).profdata.json
+	node $(MCU_PLUS_SDK_PATH)/tools/smart_placement/clang_coverage_analyse.js --input=coverage/pru_add_pru_io.$(PROFILE).profdata.json --output-json=coverage/pru_add_pru_io.$(PROFILE).analysis.json --output=../pru_add_pru_io.annotations.$(PROFILE).S --top-function-count=500
+	@echo Coverage Report Generated at $(COVERAGE_PATH)/coverage folder !!!
+
+-include $(addprefix $(OBJDIR)/, $(DEPS))

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_ccs_bootimage_gen
@@ -1,0 +1,114 @@
+#
+# Auto generated makefile
+#
+
+# Below variables need to be defined outside this file or via command line
+# - OPEN_PRU_PATH
+# - MCU_PLUS_SDK_PATH
+# - PROFILE
+# - CG_TOOL_ROOT
+# - OUTNAME
+# - CCS_INSTALL_DIR
+# - CCS_IDE_MODE
+
+CCS_PATH=$(CCS_INSTALL_DIR)
+include $(OPEN_PRU_PATH)/imports.mak
+include $(MCU_PLUS_SDK_PATH)/devconfig/devconfig.mak
+
+STRIP=$(CG_TOOL_ROOT)/bin/tiarmstrip
+OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
+ifeq ($(OS), Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
+OUTFILE=$(PROFILE)/$(OUTNAME).out
+BOOTIMAGE_PATH=$(abspath ${PROFILE})
+BOOTIMAGE_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage
+BOOTIMAGE_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage_xip
+BOOTIMAGE_NAME_SIGNED:=$(BOOTIMAGE_PATH)/$(OUTNAME).appimage.signed
+BOOTIMAGE_RPRC_NAME:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc
+BOOTIMAGE_RPRC_NAME_XIP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_xip
+BOOTIMAGE_RPRC_NAME_TMP:=$(BOOTIMAGE_PATH)/$(OUTNAME).rprc_tmp
+
+#
+# Generation of boot image which can be loaded by Secondary Boot Loader (SBL)
+#
+ifeq ($(OS),Windows_NT)
+EXE_EXT=.exe
+endif
+ifeq ($(OS),Windows_NT)
+  BOOTIMAGE_CERT_GEN_CMD=powershell -executionpolicy unrestricted -command $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.ps1
+else
+  BOOTIMAGE_CERT_GEN_CMD=$(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/x509CertificateGen.sh
+endif
+BOOTIMAGE_TEMP_OUT_FILE=$(PROFILE)/temp_stdout_$(PROFILE).txt
+
+BOOTIMAGE_CORE_ID_a53ss0-0 = 0
+BOOTIMAGE_CORE_ID_r5fss0-0 = 4
+BOOTIMAGE_CORE_ID_r5fss0-1 = 5
+BOOTIMAGE_CORE_ID_r5fss1-0 = 6
+BOOTIMAGE_CORE_ID_r5fss1-1 = 7
+BOOTIMAGE_CORE_ID_m4fss0-0 = 14
+SBL_RUN_ADDRESS=0x70000000
+SBL_DEV_ID=55
+
+MULTI_CORE_IMAGE_GEN = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/multicoreImageGen.js
+OUTRPRC_CMD = $(CCS_NODE) $(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/elf2rprc.js
+APP_IMAGE_SIGN_CMD = $(MCU_PLUS_SDK_PATH)/source/security/security_common/tools/boot/signing/appimage_x509_cert_gen.py
+
+ifeq ($(OS),Windows_NT)
+  XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.exe
+else
+  UNAME_S = $(shell uname -s)
+  ifeq ($(UNAME_S), Darwin)
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out.mac
+  else
+    XIPGEN_CMD=$(MCU_PLUS_SDK_PATH)/tools/boot/xipGen/xipGen.out
+endif
+endif
+
+MULTI_CORE_IMAGE_PARAMS = \
+	$(BOOTIMAGE_RPRC_NAME)@$(BOOTIMAGE_CORE_ID_r5fss0-0) \
+
+MULTI_CORE_IMAGE_PARAMS_XIP = \
+	$(BOOTIMAGE_RPRC_NAME_XIP)@$(BOOTIMAGE_CORE_ID_r5fss0-0)  \
+
+all:
+ifeq ($(CCS_IDE_MODE),cloud)
+#	No post build steps
+else
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME)  ...
+	$(OUTRPRC_CMD) $(OUTFILE) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(COPY) $(OUTNAME).rprc $(BOOTIMAGE_RPRC_NAME)
+	$(COPY) $(BOOTIMAGE_RPRC_NAME) $(BOOTIMAGE_RPRC_NAME_TMP)
+	$(RM) $(BOOTIMAGE_RPRC_NAME)
+	$(XIPGEN_CMD) -i $(BOOTIMAGE_RPRC_NAME_TMP) -o $(BOOTIMAGE_RPRC_NAME) -x $(BOOTIMAGE_RPRC_NAME_XIP) --flash-start-addr 0x60000000 -v > $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME) $(MULTI_CORE_IMAGE_PARAMS) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(MULTI_CORE_IMAGE_GEN) --devID $(SBL_DEV_ID) --out $(BOOTIMAGE_NAME_XIP) $(MULTI_CORE_IMAGE_PARAMS_XIP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+ifeq ($(DEVICE_TYPE),HS)
+# Sign the appimage using appimage signing script
+ifeq ($(ENC_ENABLED),no)
+	@echo Boot image signing: Encryption is disabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)
+else
+	@echo Boot image signing: Encryption is enabled.
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --enc y --enckey $(APP_ENCRYPTION_KEY) --output $(BOOTIMAGE_NAME).hs
+	$(RM) $(BOOTIMAGE_NAME)-enc
+endif
+else
+# Sign the appimage for HS-FS using appimage signing script
+	$(PYTHON) $(APP_IMAGE_SIGN_CMD) --bin $(BOOTIMAGE_NAME) --authtype 1 --key $(APP_SIGNING_KEY) --output $(BOOTIMAGE_NAME).hs_fs
+	$(RM) $(BOOTIMAGE_NAME)
+endif
+	$(RM) $(BOOTIMAGE_RPRC_NAME_TMP)
+ifeq ($(DEVICE_TYPE),HS)
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs Done !!!
+	@echo  .
+else
+	@echo  Boot image: am64x:r5fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME).hs_fs Done !!!
+	@echo  .
+endif
+endif

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/makefile_projectspec
@@ -1,0 +1,20 @@
+#
+# Auto generated makefile
+#
+
+export OPEN_PRU_PATH?=$(abspath ../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=pru_add_pru_io_am64x-evm_r5fss0-0_freertos_ti-arm-clang
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -1,0 +1,8 @@
+/*
+ *  ======== syscfg_c.rov.xs ========
+ *  This file contains the information needed by the Runtime Object
+ *  View (ROV) tool.
+ */
+var crovFiles = [
+    "kernel/freertos/rov/FreeRTOS.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/pru_add.c
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/pru_add.c
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2024-2025 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <kernel/dpl/DebugP.h>
+#include "ti_drivers_config.h"
+#include "ti_drivers_open_close.h"
+#include "ti_board_open_close.h"
+#include <drivers/pruicss.h>
+
+#include <pru0_load_bin.h>
+#include <pru1_load_bin.h>
+#if defined(SOC_AM64X) || defined(SOC_AM243X)
+#include <rtupru0_load_bin.h>
+#include <rtupru1_load_bin.h>
+#include <txpru0_load_bin.h>
+#include <txpru1_load_bin.h>
+#endif
+
+
+
+/*
+ *  This is an example project to show R5F
+ *  loading PRU firmware.
+ */
+
+/** \brief Global Structure pointer holding PRUSS1 memory Map. */
+
+PRUICSS_Handle gPruIcss0Handle;
+
+
+void pru_io_pru_add_main(void *args)
+{
+     Drivers_open(); // check return status
+
+     int status;
+     status = Board_driversOpen();
+     DebugP_assert(SystemP_SUCCESS == status);
+
+     gPruIcss0Handle = PRUICSS_open(CONFIG_PRU_ICSS0);
+
+     status = PRUICSS_initMemory(gPruIcss0Handle, PRUICSS_DATARAM(PRUICSS_PRU0));
+     DebugP_assert(status != 0);
+
+     status = PRUICSS_initMemory(gPruIcss0Handle, PRUICSS_DATARAM(PRUICSS_PRU1));
+     DebugP_assert(status != 0);
+
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_PRU0, PRU0Firmware_0, sizeof(PRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_PRU1, PRU1Firmware_0, sizeof(PRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+
+     #if defined(SOC_AM64X) || defined(SOC_AM243X)
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_RTU_PRU0, RTUPRU0Firmware_0, sizeof(RTUPRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_RTU_PRU1, RTUPRU1Firmware_0, sizeof(RTUPRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_TX_PRU0, TXPRU0Firmware_0, sizeof(TXPRU0Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     status = PRUICSS_loadFirmware(gPruIcss0Handle, PRUICSS_TX_PRU1, TXPRU1Firmware_0, sizeof(TXPRU1Firmware_0));
+     DebugP_assert(SystemP_SUCCESS == status);
+     #endif
+
+     while (1)
+     {
+        ClockP_usleep(1);
+     }
+
+     Board_driversClose();
+     Drivers_close();
+}

--- a/academy/getting_started_labs/c_code/solution/readme.md
+++ b/academy/getting_started_labs/c_code/solution/readme.md
@@ -1,0 +1,42 @@
+# PRU Getting Started Labs - getting started with C
+
+## Introduction
+
+This example acts as a getting started point for PRU firmware development in
+C.
+
+# Supported Combinations
+
+ Parameter      | Value
+ ---------------|-----------
+ ICSSG          | ICSSG0 - PRU0, PRU1, RTU0, RTU1, TX_PRU0,TX_PRU1
+ ICSSM          | ICSSM0 - PRU0, PRU1
+                | ICSSM1 - PRU0, PRU1 (am261x only)
+ Toolchain      | pru-cgt
+ Board          | am64x-evm, am243x-evm, am243x-lp, am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp
+ Example folder | academy/getting_started_labs/c_code/solution/
+
+# Steps to Run the Example
+
+> Prerequisite: [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt) should be installed at: `C:/ti/`
+
+- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU, After this `main.asm`, `linker.cmd` files gets copied to ccs workspace of PRU project. The `main.asm` contains sample code to halt PRU program
+
+     - Build the PRU project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
+          - Build Flow: Once you click on build in PRU project, firmware header file which is generated in release or debug folder of ccs workspace, is moved to  `<open-pru/academy/getting_started_labs/assembly_code/solution/firmware/device/>`
+
+     - Build the R5F project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
+          - Firmware header file path is included in R5F project include options by default, Instructions in Firmware header file can be written into PRU IRAM memory using PRUICSS_loadFirmware API (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe))
+          - Build Flow: Once you click on build in R5F project, SysConfig files are generated, Finally the R5F project will be generated using both the generated SysConfig and PRU project binaries.
+
+     - Launch a CCS debug session and run the executable, (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_LAUNCH_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_LAUNCH_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_LAUNCH_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_LAUNCH_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_LAUNCH_PAGE.html))
+
+- **When using makefiles to build**:
+     - For steps on how to use makefiles, run `make help` from the root folder
+       of the open-pru repository.
+
+# Writing PRU code
+
+* You can modify this example to write your own firmware. For more information,
+  refer to
+  [Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).

--- a/academy/getting_started_labs/makefile
+++ b/academy/getting_started_labs/makefile
@@ -1,0 +1,18 @@
+include ../../imports.mak
+
+SUBDIRS := \
+    assembly_code/solution c_and_assembly/solution \
+    c_and_inline_assembly/solution c_code/solution
+
+# "make" or "make all" builds projects that match $(DEVICE) set in imports.mak
+all: ARGUMENTS = all
+all: $(SUBDIRS)
+
+# "make clean" cleans projects that match $(DEVICE) set in imports.mak
+clean: ARGUMENTS = clean
+clean: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C $@ $(ARGUMENTS)
+
+.PHONY: all clean $(SUBDIRS)

--- a/academy/makefile
+++ b/academy/makefile
@@ -2,6 +2,7 @@ include ../imports.mak
 
 SUBDIRS := \
     crc/crc \
+    getting_started_labs \
     gpio/gpio_toggle \
     intc/intc_mcu \
     mac/mac mac/mac_multiply


### PR DESCRIPTION
### **User description**
Add the code for the PRU Getting Started Labs.

In addition to general feedback, I am looking for feedback on files with FEEDBACK comments inline:
* academy/getting_started_labs/assembly_code/main.asm
* academy/getting_started_labs/c_and_assembly/assm_add.asm


___

### **PR Type**
Enhancement


___

### **Description**
- Added comprehensive PRU Getting Started Labs with multiple learning paths: pure C code, C with assembly, C with inline assembly, and pure assembly code

- Implemented PRU firmware loaders for MCUPlus platform supporting multiple PRU cores (PRU0, PRU1, RTU, TX PRU) with PRUICSS driver initialization

- Created FreeRTOS main entry points for multiple evaluation boards (AM243x EVM/LP, AM64x EVM, AM263x/AM263Px CC/LP, AM261x LP/SOM) with system initialization and task scheduling

- Added PRU firmware implementations demonstrating addition operations using different programming approaches (pure C, inline assembly, external assembly functions)

- Included comprehensive linker command files for various PRU core types (PRU, RTU, TX PRU) across multiple SoC variants with proper memory layout configuration

- Provided lab templates with TODO placeholders for students to complete learning exercises

- Added ROV (Runtime Object View) configuration for FreeRTOS debugging support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Labs["PRU Getting Started Labs"]
  Labs --> C["Pure C Code"]
  Labs --> CA["C + Assembly"]
  Labs --> CI["C + Inline Assembly"]
  Labs --> A["Pure Assembly"]
  
  C --> FW1["PRU Firmware Loader"]
  CA --> FW1
  CI --> FW1
  A --> FW1
  
  FW1 --> Boards["Multi-Board Support"]
  Boards --> AM243["AM243x EVM/LP"]
  Boards --> AM64["AM64x EVM"]
  Boards --> AM263["AM263x/263Px CC/LP"]
  Boards --> AM261["AM261x LP/SOM"]
  
  AM243 --> FreeRTOS["FreeRTOS Main Task"]
  AM64 --> FreeRTOS
  AM263 --> FreeRTOS
  AM261 --> FreeRTOS
  
  FreeRTOS --> Cores["PRU Core Types"]
  Cores --> PRU["PRU0/PRU1"]
  Cores --> RTU["RTU PRU"]
  Cores --> TX["TX PRU"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>37 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pru_add.c</strong><dd><code>PRU firmware loader for MCUPlus platform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/pru_add.c

<ul><li>Added new C source file for PRU firmware loading demonstration<br> <li> Includes PRUICSS driver initialization and memory setup for multiple <br>PRU cores<br> <li> Loads firmware binaries for PRU0, PRU1, and conditional RTU/TX PRU <br>cores based on SOC type<br> <li> Implements main function <code>pru_io_pru_add_main()</code> with driver lifecycle <br>management</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-c1e55629fea39e9600f42ccd2b7fb8bcaba85614cd008d88ca211416ed9ed0a3">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pru_add.c</strong><dd><code>PRU firmware loader for MCUPlus platform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/mcuplus/pru_add.c

<ul><li>Added new C source file for PRU firmware loading demonstration<br> <li> Includes PRUICSS driver initialization and memory setup for multiple <br>PRU cores<br> <li> Loads firmware binaries for PRU0, PRU1, and conditional RTU/TX PRU <br>cores based on SOC type<br> <li> Implements main function <code>pru_io_pru_add_main()</code> with driver lifecycle <br>management</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-30293c0b7749141a8e4a098f0259a4b6acdf616495879fd81682774af6cfb535">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pru_add.c</strong><dd><code>PRU firmware loader for MCUPlus platform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/assembly_code/solution/mcuplus/pru_add.c

<ul><li>Added new C source file for PRU firmware loading demonstration<br> <li> Includes PRUICSS driver initialization and memory setup for multiple <br>PRU cores<br> <li> Loads firmware binaries for PRU0, PRU1, and conditional RTU/TX PRU <br>cores based on SOC type<br> <li> Implements main function <code>pru_io_pru_add_main()</code> with driver lifecycle <br>management</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-95a823187f0fdb34715c6a623b2bd31de76f430aea0795db0f2f60a8131c32eb">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pru_add.c</strong><dd><code>PRU firmware loader for MCUPlus platform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/mcuplus/pru_add.c

<ul><li>Added new C source file for PRU firmware loading demonstration<br> <li> Includes PRUICSS driver initialization and memory setup for multiple <br>PRU cores<br> <li> Loads firmware binaries for PRU0, PRU1, and conditional RTU/TX PRU <br>cores based on SOC type<br> <li> Implements main function <code>pru_io_pru_add_main()</code> with driver lifecycle <br>management</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-f7beac7b2cfdbe23b392c423f7a4de360d88d483c02a0ac1cf79362c5735daa8">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM243x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM243x EVM board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-2f4e681a4707844b4b08075c4681fc095879a9c59d086feb035c324f8e6e0178">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM64x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM64x EVM board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-c0702abf927311ad5e1fb63b49a59b0ac786dda98838c48bde3b4595050462ce">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM243x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM243x EVM board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-e7ef5b98c97a30b9175a9c868051b90e0cce8c096c5a3d6dbb95964587396c8e">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM64x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM64x EVM board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-4cc2b1c60146f1b3b01edec08a0a6015f4ef8f1a939af2ebfb71f261f67af90c">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM243x LaunchPad</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM243x LaunchPad board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-71c61ad97f84c0712ff48d8f6562d25beb39e31a8adc339fb3ff202608585b00">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM263x ControlCard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM263x ControlCard board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-5e744a845c1821241f56d2e6eb7138ccd6864811ff6d1de6812d2436534e27d6">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM263x LaunchPad</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM263x LaunchPad board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-7aa001042e82de8b3432480eb6db8013042328f9bd58f1221cc8440d36122dd8">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM243x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM243x EVM board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-cbc20e7258add69ca49e76c6af3ebe641b9a0726b3412d61f4723b8c37043f87">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM64x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM64x EVM board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-313fb0ef2aea9895fa5aa007125837cd1fc19752b169b92ba710a7c5be45cdca">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM243x LaunchPad</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM243x LaunchPad board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-5583af74a76be146488aec3dc2141827bb6a7811f4ea97d3b1912360b2e4d354">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM263x ControlCard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM263x ControlCard board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-5c2ae62f779e98c7bfd38ed73ac9376ea03633fd444a1f0f8d60c230bc196449">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM263x LaunchPad</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM263x LaunchPad board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-7fff77f14db99016b9814cb0f22d2b1ef65f671650ada1930ffb431a0820af27">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM261x LaunchPad</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM261x LaunchPad board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-c876903a1504776ead93f951f99cdfa20e2e81e2985669736b91bcc3b2fb2d8c">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM261x SOM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM261x SOM board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-633a3b1206920a63f0d88be2d042d38725adc0a8887b7e94f73662d21130fe36">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM263Px ControlCard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM263Px ControlCard board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-c3a28b96a52a395ccfddf82050a130fcaf1bfaed8775f0fe988e6715fd1d8c4f">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM263Px LaunchPad</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM263Px LaunchPad board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-c35cb72979c5db2b447652de5853e6934958cea1b3f48ee34563e80084143ca2">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM243x LaunchPad</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM243x LaunchPad board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-b81ce9439a02bdb5c89d1122d85133881fc8c0e90d6c4693f9564d4095704966">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM263x ControlCard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM263x ControlCard board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-75d963b9c618d61f693a46a314902318158c581b1bc417ff304638fb8b20f07f">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM263x LaunchPad</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM263x LaunchPad board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-a679a6e0ce9a380f473b8b40ec6ffc759a8b1555457f88555b8782f9d0e0393e">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main task entry for AM261x LaunchPad</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/main.c

<ul><li>Added FreeRTOS main entry point for AM261x LaunchPad board<br> <li> Initializes system and board drivers, creates main task with static <br>allocation<br> <li> Calls <code>pru_io_pru_add_main()</code> from FreeRTOS task context<br> <li> Starts FreeRTOS scheduler with proper task priority and stack <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-42d0759e4f89b95d57370eee807c10731fac67fb215cf2dc732ac6d5a9ef3106">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main entry point for assembly code lab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/main.c

<ul><li>Adds FreeRTOS main entry point with system initialization<br> <li> Creates static task for PRU I/O addition operation<br> <li> Configures task scheduler with highest priority task<br> <li> Includes error handling with assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-25d17db0b3b120a3050a0b3f56c225c1323b4e5d2140516da4215a8a5c96354f">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main entry point for C code lab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/main.c

<ul><li>Adds FreeRTOS main entry point with system initialization<br> <li> Creates static task for PRU I/O addition operation<br> <li> Configures task scheduler with highest priority task<br> <li> Includes error handling with assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-2bb77cc88cc061cef7db8f4b72fbc7edfe3897054e83821d3539b3e6f313e771">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main entry point for C code lab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/main.c

<ul><li>Adds FreeRTOS main entry point with system initialization<br> <li> Creates static task for PRU I/O addition operation<br> <li> Configures task scheduler with highest priority task<br> <li> Includes error handling with assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-d23de4875c3e0e90948a2e7ac0c165ec8ad816655e927355b404b06f1f78d8f3">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main entry point for C code lab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/main.c

<ul><li>Adds FreeRTOS main entry point with system initialization<br> <li> Creates static task for PRU I/O addition operation<br> <li> Configures task scheduler with highest priority task<br> <li> Includes error handling with assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-3e7e390dbf2b558293d0c9580efe06000773a186cc14b7d7d91904d61ba87050">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main entry point for C code lab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/main.c

<ul><li>Adds FreeRTOS main entry point with system initialization<br> <li> Creates static task for PRU I/O addition operation<br> <li> Configures task scheduler with highest priority task<br> <li> Includes error handling with assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-67b4ab5dc4ca382fc4e3b0456af1478924ef781248038a0e1ae26a846a6a433d">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main entry point for C code lab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/main.c

<ul><li>Adds FreeRTOS main entry point with system initialization<br> <li> Creates static task for PRU I/O addition operation<br> <li> Configures task scheduler with highest priority task<br> <li> Includes error handling with assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-22942ebab93d69b1dbdf187c942b9bd2ff2d373dd5239090037f27c45763406f">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main entry point for C code lab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/main.c

<ul><li>Adds FreeRTOS main entry point with system initialization<br> <li> Creates static task for PRU I/O addition operation<br> <li> Configures task scheduler with highest priority task<br> <li> Includes error handling with assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-1a57ae277c20ab1162ff3e031ed3922d00ee9e2fa9aa0410b83dd2ce72e144f9">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>FreeRTOS main entry point for C code lab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/main.c

<ul><li>Adds FreeRTOS main entry point with system initialization<br> <li> Creates static task for PRU I/O addition operation<br> <li> Configures task scheduler with highest priority task<br> <li> Includes error handling with assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-d5fdf9cbf8f5cdbb56743ee539ae0e5a19efd375428e3c0101f6bc321ce53ad3">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>Inline assembly addition function with memory-mapped variables</code></dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/firmware/main.c

<ul><li>Defines memory-mapped variables <code>a</code>, <code>b</code>, <code>c</code> at specific PRU memory <br>locations<br> <li> Implements <code>inline_assm_add()</code> function using inline assembly with <br><code>__asm()</code> directive<br> <li> Demonstrates adding two arguments using <code>ADD r14, r14, r15</code> instruction<br> <li> Includes TODO comments for learning exercise completion</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-9001d5df726ee51d3cc6e16bdefdde301eac93e41bf17e5493d0f169796cbf52">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>Inline assembly lab template with TODO placeholders</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/main.c

<ul><li>Defines memory-mapped variables <code>a</code>, <code>b</code> at specific PRU memory locations<br> <li> Declares <code>inline_assm_add()</code> function for students to implement<br> <li> Provides TODO comments for inline assembly implementation<br> <li> Includes incomplete function body for learning exercise</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-61ed6a547ccd9c12fd6f128376fc33479e811eba618d067ee241d0fefa086f82">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>C and assembly integration with external function calls</code>&nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/firmware/main.c

<ul><li>Defines memory-mapped variables <code>a</code>, <code>b</code>, <code>c</code> at specific PRU memory <br>locations<br> <li> Declares external assembly function <code>assm_add()</code> for addition operation<br> <li> Calls assembly function to add register and memory-mapped variables<br> <li> Includes TODO comments for learning exercise</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-9caae4edc1df192f88c1da5705598a4e9d43c4fa7362f5a236ab6ca438e47544">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>C and assembly lab template with TODO placeholders</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/main.c

<ul><li>Defines memory-mapped variables <code>a</code>, <code>b</code> at specific PRU memory locations<br> <li> Declares external assembly function <code>assm_add()</code> for students to <br>implement<br> <li> Provides TODO comments for assembly function implementation<br> <li> Includes incomplete function calls for learning exercise</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-3c5485f4c271d631614b3def815bcdadf56bdd6e2bae90360a772e5141a62299">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>Pure C code lab template with TODO placeholders</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/main.c

<ul><li>Defines memory-mapped variables <code>a</code>, <code>b</code> at specific PRU memory locations<br> <li> Provides basic C template for addition operations<br> <li> Includes TODO comments for students to implement addition logic<br> <li> Demonstrates infinite loop pattern for PRU firmware</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-0a17c99a993c8544f6bb7c0e9c53a8c9f3d36bb776ffface98665cd8d7fde6f5">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>28 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>TX_PRU1 linker command file for AM243x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Defines TX_PRU1 memory map for AM243x with instruction and data RAM <br>sections<br> <li> Configures CREGISTER mappings for peripheral access<br> <li> Allocates sections (.text, .stack, .bss, .data, etc.) to TX_PRU1 data <br>memory<br> <li> Includes shared memory and internal peripheral definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-15a7f97535b34dac231b8692ee8c933508b7292524ac70d225c43a2db2ae83f2">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>TX_PRU1 linker command file for AM64x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Defines TX_PRU1 memory map for AM64x with instruction and data RAM <br>sections<br> <li> Configures CREGISTER mappings for peripheral access<br> <li> Allocates sections (.text, .stack, .bss, .data, etc.) to TX_PRU1 data <br>memory<br> <li> Includes shared memory and internal peripheral definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-efe88501f90e6c0c97730a21e745a279d783ce2a37b4b6f774e35c64ee84918d">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>TX_PRU1 linker command file for AM243x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Defines TX_PRU1 memory map for AM243x with instruction and data RAM <br>sections<br> <li> Configures CREGISTER mappings for peripheral access<br> <li> Allocates sections (.text, .stack, .bss, .data, etc.) to TX_PRU1 data <br>memory<br> <li> Includes shared memory and internal peripheral definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-ff25b56855b47fcd7bc856a189e37c8b2ed6a7c83abdcf8958c8c4c1373f3062">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>TX_PRU1 linker command file for AM64x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Defines TX_PRU1 memory map for AM64x with instruction and data RAM <br>sections<br> <li> Configures CREGISTER mappings for peripheral access<br> <li> Allocates sections (.text, .stack, .bss, .data, etc.) to TX_PRU1 data <br>memory<br> <li> Includes shared memory and internal peripheral definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-d24e5e1dd314242f37233419c19819338b50d3ecc3fb4b9025a41affc2a8399d">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>TX_PRU0 linker command file for AM243x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd

<ul><li>Defines TX_PRU0 memory map for AM243x with instruction and data RAM <br>sections<br> <li> Configures CREGISTER mappings for peripheral access<br> <li> Allocates sections (.text, .stack, .bss, .data, etc.) to TX_PRU0 data <br>memory<br> <li> Includes shared memory and internal peripheral definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-73b3314ca77bc2b734903810234e01a9e1e1c28f0567f7a9867354d85d733969">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>TX_PRU1 linker command file for AM243x LP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Defines TX_PRU1 memory map for AM243x LP with instruction and data RAM <br>sections<br> <li> Configures CREGISTER mappings for peripheral access<br> <li> Allocates sections (.text, .stack, .bss, .data, etc.) to TX_PRU1 data <br>memory<br> <li> Includes shared memory and internal peripheral definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-d5cc7044ee0f8f54c2b631baeab3f3221e0da9bdd98cd9ca277f7ab96b9f5d2c">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>TX_PRU0 linker command file for AM64x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd

<ul><li>Defines TX_PRU0 memory map for AM64x with instruction and data RAM <br>sections<br> <li> Configures CREGISTER mappings for peripheral access<br> <li> Allocates sections (.text, .stack, .bss, .data, etc.) to TX_PRU0 data <br>memory<br> <li> Includes shared memory and internal peripheral definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-d5aefa7a882c83bbbb110b3d774b3ea77de40e198e0a4dd41efc6bfbe311b965">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>TX_PRU0 linker command file for AM243x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd

<ul><li>Defines TX_PRU0 memory map for AM243x with instruction and data RAM <br>sections<br> <li> Configures CREGISTER mappings for peripheral access<br> <li> Allocates sections (.text, .stack, .bss, .data, etc.) to TX_PRU0 data <br>memory<br> <li> Includes shared memory and internal peripheral definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-d40a89477d8c80151a070b0114ba6f010ccad3b1e8539783d7c43b9162aa1231">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>TX_PRU1 linker command file for AM243x LP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Defines TX_PRU1 memory map for AM243x LP with instruction and data RAM <br>sections<br> <li> Configures CREGISTER mappings for peripheral access<br> <li> Allocates sections (.text, .stack, .bss, .data, etc.) to TX_PRU1 data <br>memory<br> <li> Includes shared memory and internal peripheral definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-4f99da26eafab6e3e895eb6fae0d110a9a173dea48e4d4c18516108a9a758999">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>TX_PRU0 linker command file for AM64x EVM</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd

<ul><li>Defines TX_PRU0 memory map for AM64x with instruction and data RAM <br>sections<br> <li> Configures CREGISTER mappings for peripheral access<br> <li> Allocates sections (.text, .stack, .bss, .data, etc.) to TX_PRU0 data <br>memory<br> <li> Includes shared memory and internal peripheral definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-de39e7704533638961d5abf89f6b25b40506483a411c12b7595f69b9b0a3acce">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>TX_PRU0 linker command file for assembly code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd

<ul><li>Defines TX_PRU0 memory map for AM243x assembly programs with <br>instruction and data RAM<br> <li> Allocates sections (.text, .stack, .bss, .data, etc.) to TX_PRU0 data <br>memory<br> <li> Includes shared memory definition without CREGISTER mappings<br> <li> Simplified linker configuration for assembly-only code</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-7c937c21baf185fe969de59a1af466b51de1d98216307bb825f7eb4da5c34884">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM243x TX_PRU0 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM243x TX_PRU0 core compilation<br> <li> Defines memory layout with instruction RAM (6 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to TX_PRU0_DMEM_0<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-3b57e10422ec2096830c78f45209166e145a9985b99d47f940f784ec4a2c9c6e">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM243x TX_PRU0 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM243x TX_PRU0 core compilation<br> <li> Defines memory layout with instruction RAM (6 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to TX_PRU0_DMEM_0<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-f246e4e19383cad60d3ef5fabcb4730121baefac7932228592d59c5fe8fc2953">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM243x TX_PRU1 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM243x TX_PRU1 core compilation<br> <li> Defines memory layout with instruction RAM (6 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to TX_PRU1_DMEM_1<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-ce6ce4fcfd7ca80af1ba98834aa3a560072d50bc4b3dcbfabfcec4565335a4c7">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM64x TX_PRU1 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM64x TX_PRU1 core compilation<br> <li> Defines memory layout with instruction RAM (6 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to TX_PRU1_DMEM_1<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-6f02ac3d516a36ba1e1074b6774cda131158ae732ff4128f7e32e1548a0c3c92">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM243x TX_PRU0 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM243x TX_PRU0 core compilation<br> <li> Defines memory layout with instruction RAM (6 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to TX_PRU0_DMEM_0<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-dac3b1eba6c9975f53db97de736019f89f58360f869d7d1cc33d6be1cb6c0b57">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM243x TX_PRU1 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM243x TX_PRU1 core compilation<br> <li> Defines memory layout with instruction RAM (6 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to TX_PRU1_DMEM_1<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-694eefd43d5ab0f018e5ed8fc7bef42e04f2d4b9672e361b03d43f50c44a9180">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM64x TX_PRU0 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM64x TX_PRU0 core compilation<br> <li> Defines memory layout with instruction RAM (6 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to TX_PRU0_DMEM_0<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-99e6332700090d90826640d23bf4b67345334dfb4abb1118434b43c14de10941">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM243x TX_PRU0 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM243x TX_PRU0 core compilation<br> <li> Defines memory layout with instruction RAM (6 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to TX_PRU0_DMEM_0<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-38ea0b58a336e2018e04fd164244b70d814e9b724001e140b287b51709c1c7bd">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM243x PRU1 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM243x PRU1 core compilation<br> <li> Defines memory layout with instruction RAM (12 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to PRU1_DMEM_1<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-2f550ba951eafc4d40074356863273132d520dd8e14ca51acc4bb1b71a81409e">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM243x RTU1 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM243x RTU1 core compilation<br> <li> Defines memory layout with instruction RAM (8 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to RTU1_DMEM_1<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-a0f8cf686d70e2d49ebf33a203e6e741808309bc4e1b888c0acc85a8eb852662">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM64x PRU1 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM64x PRU1 core compilation<br> <li> Defines memory layout with instruction RAM (12 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to PRU1_DMEM_1<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-7fada72ebc40453cd5ecd0bc0445ddddc459a5589a890a95f0eef5d9a2ffecfa">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM64x RTU1 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM64x RTU1 core compilation<br> <li> Defines memory layout with instruction RAM (8 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to RTU1_DMEM_1<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-41943543beae5b3ef4c093face4f2bdda8e3e14d3d54ad8167109b7f705be70e">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM243x PRU1 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM243x PRU1 core compilation<br> <li> Defines memory layout with instruction RAM (12 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to PRU1_DMEM_1<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-fc07519de09f01fb4fdb2858a2b3b8a98c8c99d45024f9e5edfa8cc267fd7ef9">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM243x RTU1 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM243x RTU1 core compilation<br> <li> Defines memory layout with instruction RAM (8 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to RTU1_DMEM_1<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-71c74d538b7ed323e4b1701161798faa414886d00e17231afe3217529d38be05">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM64x PRU1 linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM64x PRU1 core compilation<br> <li> Defines memory layout with instruction RAM (12 KB), data RAMs, shared <br>memory (64 KB), and peripheral regions<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to PRU1_DMEM_1<br> <li> Includes C conventions linking and entry point configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-a3f1c4808caf48ab6130d4c0a968213efeef00839e588bd9899461979b49e6d9">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>linker.cmd</strong><dd><code>AM261x PRU0 assembly linker configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/linker.cmd

<ul><li>Added linker command file for AM261x PRU0 assembly program compilation<br> <li> Defines memory layout with instruction RAM (16 KB), data RAMs (8 KB <br>each), and shared memory (32 KB)<br> <li> Configures section allocation for text, stack, BSS, data, and other <br>standard sections to PRU0_DMEM_0<br> <li> Simplified configuration for assembly-only programs without C <br>conventions</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-ef917c6bf434fad7cc2a707de8454e1f93f1e9150def732219b6d756c0310efd">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>syscfg_c.rov.xs</strong><dd><code>FreeRTOS ROV configuration for ARM R5 core</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs

<ul><li>Added Runtime Object View (ROV) configuration file for FreeRTOS on ARM <br>R5 core<br> <li> Specifies ROV tool information needed for runtime debugging and <br>analysis<br> <li> References FreeRTOS ROV JavaScript module for runtime object <br>inspection</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-30278c545067a2cc3e08c9e0a7d351ee26bae29907aaddc6350f44e9f70cdaed">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>101 files</summary><table>
<tr>
  <td><strong>main.asm</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-12857dec8c4134150639306fa78a1a88380686a0e1b96d4c21207ebbdf578a0d">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-9ab75e38f879c527245369af70199edaf2407302158a5f580c7d209f4b81fbd1">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-1e2c452dcec8f719f05f6110201ae21bfe0626fdea6998bb754efe0e9b515580">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-60ed1744ae5e8576279de46c1e1f41ec05dc8bc21665a2d44b37d9a3330c6c52">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-84263c8e62db9f1e5b9a198f9445dddd3ff39cf893e9c93212bbe522e2a9a191">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-0205a1ea3bb03ab21b810536541439ea126b478c5ff8adca9ce0ab9d3b7d89fb">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-03bbea25f2c839ad51dd986f25f56b863cc49f1ee5a52f5b8db748a6dd3ceb69">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-39fb8f82d9dc9169b89eab2b26e828004500bf60f7f08f375ab4b2a50b8b8f00">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-053f27b6b4b41f34b3b7b3d7c729bece02efb5f022d59d359345864100ce588f">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-eadfc854caeb452cf28735ff531942fc05dd0c537515ac7941b426d0a30e0970">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-b3f524595ebb3c62cbeefdc8a1fa1ce8a6b0d97388bcc1eeab3d74922b51bde1">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-3323452e280207f5c2b986dfef7c33f19392ce018af16c630785bf2e13215c66">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-af557f37ed7206333a9bc4fb743d2cc8f56d66c5a5cbe42dbde981e09e3af77f">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-b8638a47c40cd783f296a9fd97828739b9980c6ea7f4aba42153cc22911fe163">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-f3557526dfcaff675f2405be7a9ee2ec72cc285b123134088ef5e71646172f18">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-86ebf9a98d82fb611e8096eb107ee80f27d25b366c92810e3819f112ad4781d7">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-55bc2902fa9b4ea831431e4d525d7ce2e0eb7d4c24b0a485fc907a7c6207dde6">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-cd911afcf314c58fdb78a73e1a855c59e7adac35af62a6f07a12aa6270a2119d">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-d1e4ed429e39afce6dd60f71f1b829f4c61c4cb9fafce3180e92c33b1e22c495">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-2d16830cb8d6fc2d44028dd47687976f1d2e7640c118ec392e8f3e35de1d048a">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-0f3d2194e5fe45139245100ed8db8219e1e5f40af0461cf9117613356685b3af">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-a67d47ae439a24c8ca0934220584fffcf3415cb9e2999f6eaffa26254039fc68">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-15efa09e64e8e7c1f66b4ee35ba28c01961b4a1e744dcb7b3637054821d6edad">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-31e991d455e7c38281f550e25643fbf1cf04d5b0fc8dd697e3339a98c8ab4dda">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-7ffcf4c969995cb455a8f40b2f2fd4d181b5885cf837f42c47928bb48b188c62">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-0744826125f857911726a33b702fb76ee2b041c7774678a557e5e58a1429c2e7">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-7aee09e4e5d137b64f3ebb85cc4818daa8d427b7bddbda9b1bcb9e8c152a5ce2">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-3d96c742a87fb755d92440c77a1c0acbaa4bf2d280422a8b7b780d0b2fc152a2">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-35cc71cc7eba273efe9693c3a4b0e26349984b7923c0b977ace32fe45cfec7ed">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-a6944236a753056094722a0b0793229ebdee2c472cce08ef844e94a2e8c90b0b">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-6f0947767c5b8046c9b876a2860d38aff0160373bd71cae1e4b5b60d20e38b66">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-e8af07c70d69967027733de94c37ad3262560fb0d5bf262c680fa781d2c85b28">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-3346b18b27782284cc7d05b5681954d201ca49ea1e524d56f3cc3b6239724b9b">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-df828b509d1622b0bcd8b897a3ad5159c066999efc3372d62d0130dda09049f7">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-4c0357fdc32a5a6275d35d487f2f9dcccec00bd58c0a8d405a5536faf5138bda">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-be08a3f564187d76e87e01dd4a4d8757fd27788b08b986f6d399ccbba96e1bbf">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-a4054a92309091837610012a8f06c9beaafdd95f6fc6d7d98f473b56e24db29e">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-4ebf9fd9aa37cc8bd98c1a3907ce74b47a95ac6bcf0306132e101770625db06d">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-140c9d72234df693234612efacde5e85181471d38f972f9e2416ddc993f42953">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-11f02466de6716c39d5cd3e2cc316e7f806cb98299718a291301157ba25bf388">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-ed668d732a042d518d7857e6669cf053e706cfd9ae479215a1709b12e5da4c44">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-c7a8fb89d620439bdb963d5bd822211f5b3ae90cf7d716f53ee447551c411c64">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-458c70579c760da48839b018fd3b37da4185f26fa325fcb674f0ce7b81f4853b">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-76c4240fb3341063d0c3418ccd3589e37b6100f2ee8cf483e4bda369ff1db0cc">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-ad39d52fba0fc3f9d8ef874baf594c09f366d735deea682ce4001c2717117dd8">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-056081904e5590dd64de2a8a2e18f5ea926090a50b077e99f792c74ee3b680bf">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-10bd610ba5c2b36ffb19d907c094a055d31468bea99917f038a692084a92daca">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-6d500bca384cc232cb0b04de6464359c92f47d8a0d098ea254241858cabc84b2">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-0a2cb44b32ae42377d8ccfb02f0f21f135838c39756bd109ef9435089ca5c63b">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-1ed7d6165b592c5b472fbd20fa7a2a30fcb67288203756e62f10b18df1bec683">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-01db0c2a8ccfb7bf25401c7f7a0973e7d4fad1fe7fea9a50b1e5f20c7124d1fc">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>syscfg_c.rov.xs</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-127572185d8f231a1f24c6f8c8c88d00e2092a09efe70c322abbbc4b0da9916b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-100d7daadec5c927035cdde9cdecbb339bbc64ea82d973be5306b5efdf64f81a">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-e572c153d14eb25e48db9477e043361b8b53dac2f83340eedc52c975c9f41934">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-96a27004234cf862afbf56a26bd4520d3062088391069319746251426a79cd7f">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-9e2333ce7445aeaa34e5b47bd3b848da7754a2064df7a2d40994f9c03a564238">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>syscfg_c.rov.xs</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-676cfed7d350672232249fa05e0447a27e7fe44edf36d52014bb4a75a7c4cd97">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-a1aae69ebcdef958a0ec2a818890954d9e0be448970f6d57a5bd1327eae321de">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-5f3e62e20fc08eeb69388f0b8f6ada5e0199b2a1eb24e54921ca4b11422f6353">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-91919c452033f6153a65d90c82627ba32aeee1c872a81486626053a8336ccfec">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-e1ba285c6012f1c3efae9dd659884044049ef630d16a0140a6a37a04e5a38399">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>syscfg_c.rov.xs</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-8d2c951d87d091316ef9e1aecee4b6e794357030564d756f1b07eb27c3b8b626">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-e6148f510a017d97bc5274612fe3cbf43a5694fef41e7e7880b18c7d983bfabb">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-462e8d1c7a291140f2a03cbe0a7a4c2e94a3d70e55160138d8138a80263a2896">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-f1b3072e72b6368f7c3d3781d1cbd125455be200bba2224115c8894332bbeba4">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-6e1160c3e2e7a4575b2ab2f37ce2d6affe50198c0dd4dd5d318eedcfda6cb328">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>syscfg_c.rov.xs</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-c5aaad5068985b18de431f8f8e82de9028a675213ef154350eb6f89ecd07980e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.syscfg</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-91314e1648afb67b0652f734822cdb3aee520d4bd71d5e5d23330656f254184d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-16d06c56da1171afe468f20a0c36703ea15f51e7fce58847279288d0c38e7820">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-14764716cd01b78ec66749b0dbf6b6c910775d4d2b87d3eb47872d35d55176ac">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-d4969066201aa43119ea0bb2dbfa67223135bbfd5ffeb1388d79075dcee4061e">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-80f18f9e5591e16f75972ee9f9677eff4a8b861f005dcab58b382e74be094c22">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>syscfg_c.rov.xs</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-f65d7255a09c9b2d244614ebea9c1a71818d46cd1c5182789f4fd4d79297388d">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.syscfg</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-d2b4d6b9cc4583d13a09bc7b4e4a10c4d18dd76f123c1ea68be13d98f4a42ba8">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-30a7cfcab31d8d23b724fedd7bf7cb2b6bf394f9dfe89cc388c2511d84bf7f7c">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-3fdb9cade9ae573229dbfef6d79aa10c061c22bb99d9a69081dedef2c27a5d37">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-63f95b3c22d2f715700afe24b052c81c868bbf7ee17cd34ac3e59c6e4e8bec28">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-c6901f8af7b50af6e169bc4f8f949d24d56ec3ee00d4b640ce4503447b36b045">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>syscfg_c.rov.xs</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-2434b072be080cd53521d862c3e80096f5a3a17af9c7548d123c4cbba9fee7ca">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.syscfg</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-83770d665f6f541bbdbd31ec567bb060ebb2ecd7f1d8c8ac2385fb9de86f4067">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-ef43b28ebe524ff646e4fafbd187099ac61f3dc692f210dcc7feb6d89292d5af">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-3dd784a540361acc4eb5d4790b981b973eff8ebb3bbb8b4a8b23216015c799a4">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-a30dbe0418ffeeb3b32ab3de971dbd23191a37647c89d1ee76b9ca1418864d4a">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-1041721568be4ad8c40e2101adb249367b903949acf1c12208edd27741a2d955">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>syscfg_c.rov.xs</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-19e4836473fdd6b8017929fd950b1619c8af02dee2254cdfb088da4c9ef95201">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.syscfg</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-8229d2760f545ca0f1061cb3c6bf0a0642e3fef6c7483c9ec7ab8d69874b18c3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-05ae00fb778c38b482c2cf4a5660132c7389ff7a4508b3869fdb94f61e34854c">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-f614de8bd57f4958061862fe58fdddbbd63e805f8a4fd1865b53a04363257ca9">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-54ee19df2ea7abb8dc0da87555ee465843c3a9194592d3645ab4f40adb632b40">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-2932ccec86cfda1f959e867c69fa397c32148fcf0b07350ebd8ea2c9f347b1e6">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>syscfg_c.rov.xs</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-cf49e10eaedd26122347cfe1130e349d34af1e760321ecd656eedbfb3a2b2365">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.syscfg</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-eca8120a1458cdd815d9a914e00d4b692e1c756f06115bd58138267930718289">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-343e23af159e4fcc28937a66f26abef39da3aaadabd74002ab8e707181cc0070">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-570c971328648b80153d05b45c8470a63ae15637c5f80c46be66c7ae0573d2d6">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>makefile</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-29ae71709ffd1f79f0de1402c24ac0d1f84fe900d45267bb82dc799a8788e3e8">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>makefile_projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-26543b2a9ebacc21026c7928e9cd0c113249889ae4fe81d066537b7c0dd66129">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>syscfg_c.rov.xs</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-e12b355ad898710a1db50c646d26abcedcfb9742432d6832628c361631f0349e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.syscfg</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-5bbd988cebb6cb2a67490e2039bfa8e3216d05aeeb5464f216c09fa7fb68669a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.projectspec</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-1615dcb1494b5ab9e3879e707ddf3ff289a45fbd65cb416fe4683ee660ba09f1">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>linker.cmd</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-3f97e033b7438dd36cc0b7e5988920e4dea8c870ad4c1560cd7bb14a91ba6b6d">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Additional files not shown</strong></td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/87/files#diff-2f328e4cd8dbe3ad193e49d92bcf045f47a6b72b1e9487d366f6b8288589b4ca"></a></td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

