### PR TITLE
Minor updates to Getting Started docs

### DIFF
--- a/docs/getting_started_linux.md
+++ b/docs/getting_started_linux.md
@@ -22,17 +22,24 @@ The Linux SDK is only a dependency if building code that will run on a Linux A53
 
 ### Install the tools
 
-   1. Download and install Code Composer Studio v12.8 or v20.x from [here](https://www.ti.com/tool/download/CCSTUDIO "Code Composer Studio")
-         - Please install these dependencies before installing CCS on a Linux computer. Use the command
-         ```bash
-         $ sudo apt -y install libc6:i386 libusb-0.1-4 libgconf-2-4 libncurses5 libpython2.7 libtinfo5 build-essential
-         ```
+1. Download and install Code Composer Studio v12.8 or later from [here](https://www.ti.com/tool/download/CCSTUDIO "Code Composer Studio")
+   - Please install these dependencies before installing CCS on a Linux computer. Use the command
+     ```bash
+     $ sudo apt -y install libc6:i386 libusb-0.1-4 libgconf-2-4 libncurses5 libpython2.7 libtinfo5 build-essential
+     ```
 
-   2. Download and install the PRU compiler
-      - [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt)
+   - During installation, select "custom installation". Then on the "Select
+     Components" page, select only the processors that you will be programming.
+     For example, "Sitara AM2x MCUs", or "Sitara AM3x, AM4x, AM5x and AM6x MPUs"
 
-   3. Download and install GCC for Cortex A53
-      - A53: [GNU-A](https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-elf.tar.xz)
+   - For additional information, refer to the CCS documentation,
+     [section "Installation and Updates"](https://software-dl.ti.com/ccs/esd/documents/users_guide/index_installation.html)
+
+2. Download and install the PRU compiler
+   - [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt)
+
+3. Download and install GCC for Cortex A53
+   - A53: [GNU-A](https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-elf.tar.xz)
 
 
 ## Set up imports.mak

--- a/docs/getting_started_mcuplus.md
+++ b/docs/getting_started_mcuplus.md
@@ -41,9 +41,17 @@ If **the MCU+ SDK repository** is used, please follow the steps on page
 > Refer to the documentation associated with your specific SDK release
 
 Install the versions of the tools that are listed in these pages:
+
    - MCU+ SDK docs > Getting Started > Download, Install, and Setup SDK and Tools
+
    - MCU+ SDK docs > Getting Started > Download, Install, and Setup CCS
-     - Developers using a Linux computer, make sure to follow the additional steps at "CCS Linux Host Support"
+
+     - Developers using a Linux computer, make sure to follow the additional
+       steps at "CCS Linux Host Support"
+
+     - If section **Create Target Configuration** says to “Bypass not used CPUs”,
+       **do NOT bypass the ICSS / ICSS_G cores**. The CCS debugger cannot connect
+       to a PRU core if the PRU core has been bypassed
 
 ## Set up imports.mak
 

--- a/docs/getting_started_mcuplus_repo.md
+++ b/docs/getting_started_mcuplus_repo.md
@@ -37,8 +37,15 @@ mcupsdk-core README.md file for additional steps to set up the repository.
 
 Install the versions of the tools that are listed in these pages:
    - MCU+ SDK docs > Getting Started > Download, Install, and Setup SDK and Tools
+
    - MCU+ SDK docs > Getting Started > Download, Install, and Setup CCS
-     - Developers using a Linux computer, make sure to follow the additional steps at "CCS Linux Host Support"
+
+     - Developers using a Linux computer, make sure to follow the additional
+       steps at "CCS Linux Host Support"
+
+     - If section **Create Target Configuration** says to “Bypass not used CPUs”,
+       **do NOT bypass the ICSS / ICSS_G cores**. The CCS debugger cannot connect
+       to a PRU core if the PRU core has been bypassed
 
 ## Set up imports.mak
 


### PR DESCRIPTION
### **User description**
Fix formatting, add note that PRU cores should not be disabled in CCS settings.


___

### **PR Type**
Documentation


___

### **Description**
- Fix markdown formatting in numbered lists and indentation

- Add CCS custom installation instructions for processor selection

- Add critical warning about not disabling PRU/ICSS cores in CCS

- Add reference to CCS installation documentation

- Fix line endings in multiple files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Getting Started Docs"] --> B["Formatting Fixes"]
  A --> C["CCS Installation Info"]
  A --> D["PRU Core Warning"]
  C --> E["Custom Installation Steps"]
  C --> F["Documentation Link"]
  D --> G["Do NOT bypass ICSS cores"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getting_started_linux.md</strong><dd><code>Improve CCS installation instructions and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/getting_started_linux.md

<ul><li>Fixed markdown list formatting from indented to standard numbered list<br> <li> Changed CCS version requirement from "v12.8 or v20.x" to "v12.8 or <br>later"<br> <li> Added instructions for custom CCS installation with processor <br>selection<br> <li> Added reference link to CCS installation documentation<br> <li> Fixed file line ending</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/105/files#diff-10d593d3b84589f27b5e40848a7eeb61efe8476b01bec28e463e7e4b4c053fc2">+17/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>getting_started_mcuplus.md</strong><dd><code>Add PRU core bypass warning for MCU+ SDK</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/getting_started_mcuplus.md

<ul><li>Added warning about not bypassing ICSS/ICSS_G cores in CCS target <br>configuration<br> <li> Improved line wrapping for Linux-specific CCS instructions<br> <li> Added spacing between list items for better readability<br> <li> Fixed file line ending</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/105/files#diff-22c2168a89d1270ad7763014003c2bee7e2607a8ff2b2b6f925802d05602d364">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>getting_started_mcuplus_repo.md</strong><dd><code>Add PRU core bypass warning for MCU+ repo setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/getting_started_mcuplus_repo.md

<ul><li>Added warning about not bypassing ICSS/ICSS_G cores in CCS target <br>configuration<br> <li> Improved line wrapping for Linux-specific CCS instructions<br> <li> Added spacing between list items for better readability<br> <li> Fixed file line ending</ul>


</details>


  </td>
  <td><a href="https://github.com/TexasInstruments/open-pru/pull/105/files#diff-dff89ec620d61759100dba9f7e6170b882ea954da7c729e51449276ba0807633">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

