### PR TITLE
PRU Academy updates - merge after PR125

### DIFF
--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM62X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,7 @@ EXPECTED_DEVICE := am62x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM62X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,7 @@ EXPECTED_DEVICE := am62x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM62X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,7 @@ EXPECTED_DEVICE := am62x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM62X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,7 @@ EXPECTED_DEVICE := am62x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM62X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,7 @@ EXPECTED_DEVICE := am62x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM62X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,7 @@ EXPECTED_DEVICE := am62x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM243X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am243x-lp/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am243x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM261X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am261x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263PX
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263px
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM263X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am263x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v3
             -DSOC_AM62X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
@@ -29,6 +29,7 @@ EXPECTED_DEVICE := am62x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v3
             -DSOC_AM62X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile
@@ -29,6 +29,7 @@ EXPECTED_DEVICE := am62x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_rtu_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE0
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru0_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/example.projectspec
@@ -39,7 +39,7 @@
             -DSLICE1
             -v4
             -DSOC_AM64X
-            -O2
+            -Ooff
         "
         linkerBuildOptions="
             -m=pru_add.${ConfigName}.map

--- a/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/getting_started_labs/c_code/solution/firmware/am64x-evm/icss_g0_tx_pru1_fw/ti-pru-cgt/makefile
@@ -27,6 +27,7 @@ EXPECTED_DEVICE := am64x
 # Optional:
 # Pre-define here to override default value
 #   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+OPT_LEVEL := off
 
 # pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
 include $(OPEN_PRU_PATH)/pru_rules.mak

--- a/docs/open_pru_organization.md
+++ b/docs/open_pru_organization.md
@@ -58,8 +58,12 @@ pru_spi
 ```
 
 > [!NOTE]
-> If the PRU code must be modified in order to interact with different cores or
-> operating systems, it is suggested to create a separate project for each
+> If only small code changes are required to enable PRU code to interact with
+> different cores or operating systems, Instance-specific defines may be added
+> to the PRU core's makefile to make the code compile differently. See `DFLAGS`
+> in the PRU core's makefile. However, if significant PRU code changes are
+> required in order to interact with different cores or operating systems, it is
+> suggested to create a separate project for each
 > version of the PRU firmware.
 
 #### MCU+ source code

--- a/pull_requests/125_review.txt
+++ b/pull_requests/125_review.txt
@@ -1,1 +1,0 @@
-I approve this pull request.


### PR DESCRIPTION
These are updates to the OpenPRU repo that were discovered while writing PRU Academy 2026.01.00. This branch is based on PR125, so do not merge until after PR125 has been merged.