### PR TITLE
Remove syscfg rov from PRU, update MCU+ cores

### DIFF
--- a/academy/crc/crc/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/crc/crc/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/crc/crc/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/crc/crc/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/crc/crc/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/crc/crc/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/crc/crc/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/crc/crc/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/crc/crc/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/crc/crc/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/crc/crc/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/crc/crc/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/crc/crc/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/gpio/gpio_toggle/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/gpio/gpio_toggle/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/gpio/gpio_toggle/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/gpio/gpio_toggle/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/gpio/gpio_toggle/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/gpio/gpio_toggle/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/gpio/gpio_toggle/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/gpio/gpio_toggle/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/gpio/gpio_toggle/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/gpio/gpio_toggle/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/gpio/gpio_toggle/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/gpio/gpio_toggle/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/gpio/gpio_toggle/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/gpio/gpio_toggle/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/intc/intc_mcu/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/intc/intc_mcu/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/intc/intc_mcu/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/intc/intc_mcu/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/intc/intc_mcu/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/academy/intc/intc_mcu/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/intc/intc_mcu/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/intc/intc_mcu/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/intc/intc_mcu/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/intc/intc_mcu/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/intc/intc_mcu/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/intc/intc_mcu/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/intc/intc_mcu/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/intc/intc_mcu/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/intc/intc_mcu/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/intc/intc_mcu/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/academy/mac/mac_multiply/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/academy/mac/mac_multiply/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/LCD_interface/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/LCD_interface/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty_c/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am261x-som/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am261x-som/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am263px-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am263px-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am263px-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am263px-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am263x-cc/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am263x-cc/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am263x-lp/icss_m0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/empty_c/firmware/am263x-lp/icss_m0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/empty_c/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty_c/mcuplus/am243x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty_c/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty_c/mcuplus/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty_c/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty_c/mcuplus/am261x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty_c/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty_c/mcuplus/am261x-som/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty_c/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty_c/mcuplus/am263px-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty_c/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty_c/mcuplus/am263px-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty_c/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty_c/mcuplus/am263x-cc/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty_c/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty_c/mcuplus/am263x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/empty_c/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/empty_c/mcuplus/am64x-evm/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/pru_emif/pru_emif_app/am243x-evm/r5fss0-0_nortos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/pru_emif/pru_emif_app/am243x-evm/r5fss0-0_nortos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/rpmsg_echo_linux/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/rpmsg_echo_linux/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/rpmsg_echo_linux/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
+++ b/examples/rpmsg_echo_linux/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/syscfg_c.rov.xs
@@ -1,8 +1,0 @@
-/*
- *  ======== syscfg_c.rov.xs ========
- *  This file contains the information needed by the Runtime Object
- *  View (ROV) tool.
- */
-var crovFiles = [
-    "kernel/freertos/rov/FreeRTOS.rov.js",
-];

--- a/examples/spi_loopback/spi_loopback_app/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/spi_loopback/spi_loopback_app/am243x-lp/r5fss0-0_freertos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];

--- a/examples/spi_loopback/spi_loopback_app/am243x-lp/r5fss0-0_nortos/ti-arm-clang/syscfg_c.rov.xs
+++ b/examples/spi_loopback/spi_loopback_app/am243x-lp/r5fss0-0_nortos/ti-arm-clang/syscfg_c.rov.xs
@@ -6,3 +6,7 @@
 var crovFiles = [
     "kernel/freertos/rov/FreeRTOS.rov.js",
 ];
+
+var objectViewerFiles = [
+    "kernel/freertos/rov_theia/FreeRTOS_Theia.rov.js",
+];


### PR DESCRIPTION
syscfg_c.rov.xs is only used by the ROV tool in CCS when debugging an MCU+ FreeRTOS project, so it can be removed from all PRU firmware projects.

changes confirmed by CCS team here: https://e2e.ti.com/support/tools/code-composer-studio-group/ccs/f/code-composer-studio-forum/1631976/am6442-is-syscfg_c-rov-xs-used-when-debugging-pru-cores

This PR is dependent upon PR125, Please merge that PR before merging this one.