### PR TITLE
Update all READMEs, port HW UART & MAC C code examples from PSSP

### DIFF
--- a/academy/crc/crc/readme.md
+++ b/academy/crc/crc/readme.md
@@ -19,11 +19,25 @@ The example code configures the CRC module, performs the calculations, and store
 
 This implementation is particularly useful in applications requiring data integrity validation, error detection in communication protocols, and verification of data transmission accuracy. The example runs on various AM26x family processors and demonstrates the essential features of the PRU CRC module in a straightforward manner.
 
-# Supported Combinations
+## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSM          | ICSSM0 - PRU0, PRU1; ICSSM1 (only in am261x) - PRU0, PRU1
- Toolchain      | pru-cgt
- Board          | am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp
- Example folder | academy/crc/crc/
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+
+## Steps to Run the Example
+
+1. Build and run the PRU firmware
+2. After program halts, inspect the PRU register values:
+   - R10: CRC16 result
+   - R11: CRC32 result

--- a/academy/crc/crc/readme.md
+++ b/academy/crc/crc/readme.md
@@ -31,9 +31,9 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am261x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263px   | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
 
 ## Steps to Run the Example
 

--- a/academy/getting_started_labs/assembly_code/solution/readme.md
+++ b/academy/getting_started_labs/assembly_code/solution/readme.md
@@ -2,40 +2,34 @@
 
 ## Introduction
 
-This example acts as a getting started point for PRU firmware development in assembly.
+This is a training lab for getting started with PRU firmware development in
+assembly.
 
-# Supported Combinations
+## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSG          | ICSSG0 - PRU0, PRU1, RTU0, RTU1, TX_PRU0,TX_PRU1
- ICSSM          | ICSSM0 - PRU0, PRU1
-                | ICSSM1 - PRU0, PRU1 (am261x only)
- Toolchain      | pru-cgt
- Board          | am64x-evm, am243x-evm, am243x-lp, am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp
- Example folder | academy/getting_started_labs/assembly_code/solution/
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
 
-# Steps to Run the Example
+## Validated HW & SW
 
-> Prerequisite: [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt) should be installed at: `C:/ti/`
+This project was tested on hardware with these software versions:
 
-- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU, After this `main.asm`, `linker.cmd` files gets copied to ccs workspace of PRU project. The `main.asm` contains sample code to halt PRU program
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am243x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am62x     | TODO     | OpenPRU TODO                            |
+| am64x     | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
 
-     - Build the PRU project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Build Flow: Once you click on build in PRU project, firmware header file which is generated in release or debug folder of ccs workspace, is moved to  `<open-pru/academy/getting_started_labs/assembly_code/solution/firmware/device/>`
+## Steps to Run the Example
 
-     - Build the R5F project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Firmware header file path is included in R5F project include options by default, Instructions in Firmware header file can be written into PRU IRAM memory using PRUICSS_loadFirmware API (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe))
-          - Build Flow: Once you click on build in R5F project, SysConfig files are generated, Finally the R5F project will be generated using both the generated SysConfig and PRU project binaries.
-
-     - Launch a CCS debug session and run the executable, (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_LAUNCH_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_LAUNCH_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_LAUNCH_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_LAUNCH_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_LAUNCH_PAGE.html))
-
-- **When using makefiles to build**:
-     - For steps on how to use makefiles, run `make help` from the root folder
-       of the open-pru repository.
-
-# Writing PRU code
-
-* You can modify this example to write your own firmware. For more information,
-  refer to
-  [Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).
+1. Build the project. Refer to the **PRU Getting Started Labs > Lab 3: How to
+   Build PRU Firmware** for details.
+2. Load the firmware onto the PRU core using CCS, an MCU+ core, or a Linux
+   core. Refer to the **PRU Getting
+   Started Labs > Lab 4: How to Initialize the PRU** for details.
+3. Run the PRU firmware and debug as discussed in the **PRU Getting
+   Started Labs > Lab 5: How to debug PRU firmware**.

--- a/academy/getting_started_labs/assembly_code/solution/readme.md
+++ b/academy/getting_started_labs/assembly_code/solution/readme.md
@@ -17,12 +17,12 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am243x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am62x     | TODO     | OpenPRU TODO                            |
-| am64x     | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am243x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am261x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263px   | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am62x     | FIXME     | OpenPRU FIXME                            |
+| am64x     | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
 
 ## Steps to Run the Example
 

--- a/academy/getting_started_labs/c_and_assembly/solution/readme.md
+++ b/academy/getting_started_labs/c_and_assembly/solution/readme.md
@@ -2,41 +2,34 @@
 
 ## Introduction
 
-This example acts as a getting started point for PRU firmware development
-with mixed C and assembly.
+This is a training lab for getting started with PRU firmware development
+in mixed C and assembly.
 
-# Supported Combinations
+## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSG          | ICSSG0 - PRU0, PRU1, RTU0, RTU1, TX_PRU0,TX_PRU1
- ICSSM          | ICSSM0 - PRU0, PRU1
-                | ICSSM1 - PRU0, PRU1 (am261x only)
- Toolchain      | pru-cgt
- Board          | am64x-evm, am243x-evm, am243x-lp, am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp
- Example folder | academy/getting_started_labs/c_and_assembly/solution/
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
 
-# Steps to Run the Example
+## Validated HW & SW
 
-> Prerequisite: [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt) should be installed at: `C:/ti/`
+This project was tested on hardware with these software versions:
 
-- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU, After this `main.asm`, `linker.cmd` files gets copied to ccs workspace of PRU project. The `main.asm` contains sample code to halt PRU program
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am243x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am62x     | TODO     | OpenPRU TODO                            |
+| am64x     | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
 
-     - Build the PRU project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Build Flow: Once you click on build in PRU project, firmware header file which is generated in release or debug folder of ccs workspace, is moved to  `<open-pru/academy/getting_started_labs/assembly_code/solution/firmware/device/>`
+## Steps to Run the Example
+1. Build the project. Refer to the **PRU Getting Started Labs > Lab 3: How to
+   Build PRU Firmware** for details.
+2. Load the firmware onto the PRU core using CCS, an MCU+ core, or a Linux
+   core. Refer to the **PRU Getting
+   Started Labs > Lab 4: How to Initialize the PRU** for details.
+3. Run the PRU firmware and debug as discussed in the **PRU Getting
+   Started Labs > Lab 5: How to debug PRU firmware**.
 
-     - Build the R5F project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Firmware header file path is included in R5F project include options by default, Instructions in Firmware header file can be written into PRU IRAM memory using PRUICSS_loadFirmware API (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe))
-          - Build Flow: Once you click on build in R5F project, SysConfig files are generated, Finally the R5F project will be generated using both the generated SysConfig and PRU project binaries.
-
-     - Launch a CCS debug session and run the executable, (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_LAUNCH_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_LAUNCH_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_LAUNCH_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_LAUNCH_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_LAUNCH_PAGE.html))
-
-- **When using makefiles to build**:
-     - For steps on how to use makefiles, run `make help` from the root folder
-       of the open-pru repository.
-
-# Writing PRU code
-
-* You can modify this example to write your own firmware. For more information,
-  refer to
-  [Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).

--- a/academy/getting_started_labs/c_and_assembly/solution/readme.md
+++ b/academy/getting_started_labs/c_and_assembly/solution/readme.md
@@ -17,12 +17,12 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am243x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am62x     | TODO     | OpenPRU TODO                            |
-| am64x     | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am243x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am261x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263px   | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am62x     | FIXME     | OpenPRU FIXME                            |
+| am64x     | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
 
 ## Steps to Run the Example
 1. Build the project. Refer to the **PRU Getting Started Labs > Lab 3: How to

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/readme.md
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/readme.md
@@ -2,41 +2,35 @@
 
 ## Introduction
 
-This example acts as a getting started point for PRU firmware development with
+This is a training lab for getting started with PRU firmware development in
 mixed C and inline assembly.
 
-# Supported Combinations
+## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSG          | ICSSG0 - PRU0, PRU1, RTU0, RTU1, TX_PRU0,TX_PRU1
- ICSSM          | ICSSM0 - PRU0, PRU1
-                | ICSSM1 - PRU0, PRU1 (am261x only)
- Toolchain      | pru-cgt
- Board          | am64x-evm, am243x-evm, am243x-lp, am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp
- Example folder | academy/getting_started_labs/c_and_inline_assembly/solution/
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
 
-# Steps to Run the Example
+## Validated HW & SW
 
-> Prerequisite: [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt) should be installed at: `C:/ti/`
+This project was tested on hardware with these software versions:
 
-- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU, After this `main.asm`, `linker.cmd` files gets copied to ccs workspace of PRU project. The `main.asm` contains sample code to halt PRU program
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am243x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am62x     | TODO     | OpenPRU TODO                            |
+| am64x     | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
 
-     - Build the PRU project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Build Flow: Once you click on build in PRU project, firmware header file which is generated in release or debug folder of ccs workspace, is moved to  `<open-pru/academy/getting_started_labs/assembly_code/solution/firmware/device/>`
+## Steps to Run the Example
 
-     - Build the R5F project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Firmware header file path is included in R5F project include options by default, Instructions in Firmware header file can be written into PRU IRAM memory using PRUICSS_loadFirmware API (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe))
-          - Build Flow: Once you click on build in R5F project, SysConfig files are generated, Finally the R5F project will be generated using both the generated SysConfig and PRU project binaries.
+1. Build the project. Refer to the **PRU Getting Started Labs > Lab 3: How to
+   Build PRU Firmware** for details.
+2. Load the firmware onto the PRU core using CCS, an MCU+ core, or a Linux
+   core. Refer to the **PRU Getting
+   Started Labs > Lab 4: How to Initialize the PRU** for details.
+3. Run the PRU firmware and debug as discussed in the **PRU Getting
+   Started Labs > Lab 5: How to debug PRU firmware**.
 
-     - Launch a CCS debug session and run the executable, (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_LAUNCH_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_LAUNCH_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_LAUNCH_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_LAUNCH_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_LAUNCH_PAGE.html))
-
-- **When using makefiles to build**:
-     - For steps on how to use makefiles, run `make help` from the root folder
-       of the open-pru repository.
-
-# Writing PRU code
-
-* You can modify this example to write your own firmware. For more information,
-  refer to
-  [Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/readme.md
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/readme.md
@@ -17,12 +17,12 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am243x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am62x     | TODO     | OpenPRU TODO                            |
-| am64x     | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am243x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am261x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263px   | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am62x     | FIXME     | OpenPRU FIXME                            |
+| am64x     | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
 
 ## Steps to Run the Example
 

--- a/academy/getting_started_labs/c_code/solution/readme.md
+++ b/academy/getting_started_labs/c_code/solution/readme.md
@@ -2,41 +2,34 @@
 
 ## Introduction
 
-This example acts as a getting started point for PRU firmware development in
-C.
+This is a training lab for getting started with PRU firmware development in C.
 
-# Supported Combinations
+## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSG          | ICSSG0 - PRU0, PRU1, RTU0, RTU1, TX_PRU0,TX_PRU1
- ICSSM          | ICSSM0 - PRU0, PRU1
-                | ICSSM1 - PRU0, PRU1 (am261x only)
- Toolchain      | pru-cgt
- Board          | am64x-evm, am243x-evm, am243x-lp, am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp
- Example folder | academy/getting_started_labs/c_code/solution/
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
 
-# Steps to Run the Example
+## Validated HW & SW
 
-> Prerequisite: [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt) should be installed at: `C:/ti/`
+This project was tested on hardware with these software versions:
 
-- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU, After this `main.asm`, `linker.cmd` files gets copied to ccs workspace of PRU project. The `main.asm` contains sample code to halt PRU program
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am243x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am62x     | TODO     | OpenPRU TODO                            |
+| am64x     | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
 
-     - Build the PRU project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Build Flow: Once you click on build in PRU project, firmware header file which is generated in release or debug folder of ccs workspace, is moved to  `<open-pru/academy/getting_started_labs/assembly_code/solution/firmware/device/>`
+## Steps to Run the Example
 
-     - Build the R5F project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Firmware header file path is included in R5F project include options by default, Instructions in Firmware header file can be written into PRU IRAM memory using PRUICSS_loadFirmware API (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe))
-          - Build Flow: Once you click on build in R5F project, SysConfig files are generated, Finally the R5F project will be generated using both the generated SysConfig and PRU project binaries.
+1. Build the project. Refer to the **PRU Getting Started Labs > Lab 3: How to
+   Build PRU Firmware** for details.
+2. Load the firmware onto the PRU core using CCS, an MCU+ core, or a Linux
+   core. Refer to the **PRU Getting
+   Started Labs > Lab 4: How to Initialize the PRU** for details.
+3. Run the PRU firmware and debug as discussed in the **PRU Getting
+   Started Labs > Lab 5: How to debug PRU firmware**.
 
-     - Launch a CCS debug session and run the executable, (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_LAUNCH_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_LAUNCH_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_LAUNCH_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_LAUNCH_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_LAUNCH_PAGE.html))
-
-- **When using makefiles to build**:
-     - For steps on how to use makefiles, run `make help` from the root folder
-       of the open-pru repository.
-
-# Writing PRU code
-
-* You can modify this example to write your own firmware. For more information,
-  refer to
-  [Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).

--- a/academy/getting_started_labs/c_code/solution/readme.md
+++ b/academy/getting_started_labs/c_code/solution/readme.md
@@ -16,12 +16,12 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am243x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am62x     | TODO     | OpenPRU TODO                            |
-| am64x     | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am243x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am261x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263px   | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am62x     | FIXME     | OpenPRU FIXME                            |
+| am64x     | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
 
 ## Steps to Run the Example
 

--- a/academy/gpio/gpio_toggle/readme.md
+++ b/academy/gpio/gpio_toggle/readme.md
@@ -16,12 +16,25 @@ In both cases, the toggled signal is routed to a readily accessible location on 
 
 The oscillating signal generated can be used to validate proper PRU operation and GPIO configuration, making this example particularly useful for initial hardware bring-up and verification of PRU GPIO functionality.
 
-# Supported Combinations
+## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSM          | ICSSM0 - PRU0, PRU1; ICSSM1 (only in am261x) - PRU0, PRU1
- Toolchain      | pru-cgt
- Board          | am261x-lp, am263px-lp, am263x-lp
- Example folder | academy/gpio/gpio_toggle
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+
+## Steps to Run the Example
+
+1. Build and run the PRU firmware
+2. Connect a logic analyzer or oscilloscope to header pin BP.17 (J2) and
+   observe the toggling signal
 

--- a/academy/gpio/gpio_toggle/readme.md
+++ b/academy/gpio/gpio_toggle/readme.md
@@ -28,9 +28,9 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am261x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263px   | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
 
 ## Steps to Run the Example
 

--- a/academy/intc/intc_mcu/intc_mcu.c
+++ b/academy/intc/intc_mcu/intc_mcu.c
@@ -98,7 +98,7 @@ int32_t PRUICSS_goToSection(PRUICSS_Handle handle, uint32_t pruCore, uint32_t se
         else
             return SystemP_FAILURE;
 
-        /* TODO: decide the final memory and offset */
+        /* FIXME: decide the final memory and offset */
         CSL_REG32_WR(baseaddr + PRUICSS_PRGM_FLOW_CNTRL_OFFSET, sectionId);
         retVal = PRUICSS_sendEvent(handle, eventNum);
     }

--- a/academy/intc/intc_mcu/readme.md
+++ b/academy/intc/intc_mcu/readme.md
@@ -20,12 +20,26 @@ The successful completion of this interrupt sequence can be verified by checking
 - The R5F successfully generated a response interrupt
 - The PRU correctly received and handled the response interrupt
 
-# Supported Combinations
+## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSM          | ICSSM0 - PRU0, PRU1; ICSSM1 (only in am261x) - PRU0, PRU1
- Toolchain      | pru-cgt
- Board          | am261x-lp, am263px-cc, am263px-lp, am263x-cc, am263x-lp
- Example folder | academy/intc/intc_mcu
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+
+## Steps to Run the Example
+
+1. Build and run the PRU firmware.
+2. After the firmware finishes running, Inspect PRU register R11. The expected
+   value is `0x12345678`, confirming
+   that the full PRU ↔ R5F interrupt handshake completed successfully.
 

--- a/academy/intc/intc_mcu/readme.md
+++ b/academy/intc/intc_mcu/readme.md
@@ -32,9 +32,9 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am261x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263px   | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
 
 ## Steps to Run the Example
 

--- a/academy/mac/mac/readme.md
+++ b/academy/mac/mac/readme.md
@@ -22,11 +22,25 @@ The final result is stored across two PRU registers:
 - R26: Contains the lower 32 bits of the result
 - R27: Contains the upper 32 bits of the result
 
-# Supported Combinations
+## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSM          | ICSSM0 - PRU0, PRU1; ICSSM1 (only in am261x) - PRU0, PRU1
- Toolchain      | pru-cgt
- Board          | am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp
- Example folder | academy/mac/mac/
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+
+## Steps to Run the Example
+
+1. Build and run the PRU firmware.
+2. After the firmware finishes running, inspect the PRU register values:
+   - R26: lower 32 bits of the dot product result; expected `0x20` (32 decimal)
+   - R27: upper 32 bits; expected `0x00`

--- a/academy/mac/mac/readme.md
+++ b/academy/mac/mac/readme.md
@@ -34,9 +34,9 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am261x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263px   | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
 
 ## Steps to Run the Example
 

--- a/academy/mac/mac_c/README.md
+++ b/academy/mac/mac_c/README.md
@@ -1,5 +1,10 @@
 # MAC Multiply-Accumulate (C)
 
+## Introduction
+
+This example demonstrates the PRU MAC (Multiply and Accumulate) hardware
+accelerator using PRU C firmware.
+
 ## Overview
 
 This example demonstrates the PRU MAC (Multiply and Accumulate) hardware
@@ -17,14 +22,9 @@ fits within the target device's Data RAM.
 
 ## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- PRU subsystem  | PRUSS0 - PRU0, PRU1 (AM62x); ICSS_G0 - PRU0, PRU1 (AM64x)
- Toolchain      | pru-cgt
- Board          | am62x-sk, am64x-evm
- Example folder | academy/mac/mac_c/
-
-For portability to other devices, see [academy/readme.md §Supported processors per-project](../../readme.md#supported-processors-per-project).
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
 
 ## Validated HW & SW
 

--- a/academy/mac/mac_c/README.md
+++ b/academy/mac/mac_c/README.md
@@ -1,0 +1,52 @@
+# MAC Multiply-Accumulate (C)
+
+## Overview
+
+This example demonstrates the PRU MAC (Multiply and Accumulate) hardware
+accelerator using PRU C firmware. It allocates 256 pairs of 32-bit operands
+in PRU Data RAM, fills them with sequential values, performs 256
+multiply-accumulate operations accumulating a 64-bit result, stores the
+result, and halts.
+
+The example is adapted from the PRU Software Support Package (PSSP)
+`PRU_MAC_Multiply_Accum` example.
+
+The 256-entry operand buffer (`buf`) uses 2 KB (0x800 bytes) of PRU Data RAM.
+After building, inspect the `.map` file to verify the total Data RAM usage
+fits within the target device's Data RAM.
+
+## Supported Combinations
+
+ Parameter      | Value
+ ---------------|-----------
+ PRU subsystem  | PRUSS0 - PRU0, PRU1 (AM62x); ICSS_G0 - PRU0, PRU1 (AM64x)
+ Toolchain      | pru-cgt
+ Board          | am62x-sk, am64x-evm
+ Example folder | academy/mac/mac_c/
+
+For portability to other devices, see [academy/readme.md §Supported processors per-project](../../readme.md#supported-processors-per-project).
+
+## Validated HW & SW
+
+- Board: SK-AM62B, TMDS64EVM
+- TI PRU Code Generation Tools (CGT) v2.3.3
+- Code Composer Studio 20.x
+- OpenPRU v2026.01.00
+
+## Running and Validating
+
+1. Load the built ELF onto the target PRU core using CCS. Refer to the **PRU
+   Getting Started Labs > Lab 4: How to Initialize the PRU** for details.
+2. Run the PRU core.
+3. Halt execution at `__halt()`.
+4. Inspect the value in `storeValue`. Refer to the **PRU Getting Started Labs >
+   Lab 5: How to debug PRU firmware** for details.
+   * The expected accumulated result in storeValue is 5,592,320 = 0x555500 [1]
+
+[1] Calculation for storeValue:
+Each iteration contributes i * (i+1) = i² + i, so:
+result = Σ(i=0 to 255) (i² + i) = Σi² + Σi
+Using the standard closed-form formulas for sums up to n=255:
+ - Σi (0→255) = 255×256/2 = 32,640
+ - Σi² (0→255) = 255×256×511/6 = 5,559,680
+ - result = 32,640 + 5,559,680 = 5,592,320 = 0x555500

--- a/academy/mac/mac_c/README.md
+++ b/academy/mac/mac_c/README.md
@@ -1,0 +1,56 @@
+# MAC Multiply-Accumulate (C)
+
+## Introduction
+
+This example implements Multiply and Accumulate functionality in C. It does NOT
+currently use the PRU MAC (Multiply and Accumulate) hardware accelerator.
+
+## Overview
+
+This example allocates 256 pairs of 32-bit operands
+in PRU Data RAM, fills them with sequential values, performs 256
+multiply-accumulate operations accumulating a 64-bit result, stores the
+result, and halts.
+
+The example is adapted from the PRU Software Support Package (PSSP)
+`PRU_MAC_Multiply_Accum` example.
+
+The 256-entry operand buffer (`buf`) uses 2 KB (0x800 bytes) of PRU Data RAM.
+After building, inspect the `.map` file to verify the total Data RAM usage
+fits within the target device's Data RAM.
+
+## Supported Combinations
+
+ Parameter      | Value
+ ---------------|-----------
+ PRU subsystem  | PRUSS0 - PRU0, PRU1 (AM62x); ICSS_G0 - PRU0, PRU1 (AM64x)
+ Toolchain      | pru-cgt
+ Board          | am62x-sk, am64x-evm
+ Example folder | academy/mac/mac_c/
+
+For portability to other devices, see [academy/readme.md §Supported processors per-project](../../readme.md#supported-processors-per-project).
+
+## Validated HW & SW
+
+| Processor | Hardware  | Software                                                                    |
+|-----------|-----------|-----------------------------------------------------------------------------|
+| AM62x     | SK-AM62B  | TI PRU CGT v2.3.3, CCS 12.7, OpenPRU v2026.01.00          |
+| AM64x     | TMDS64EVM | TI PRU CGT v2.3.3, CCS 12.7, OpenPRU v2026.01.00          |
+
+## Running and Validating
+
+1. Load the built ELF onto the target PRU core using CCS. Refer to the **PRU
+   Getting Started Labs > Lab 4: How to Initialize the PRU** for details.
+2. Run the PRU core.
+3. Halt execution at `__halt()`.
+4. Inspect the value in `storeValue`. Refer to the **PRU Getting Started Labs >
+   Lab 5: How to debug PRU firmware** for details.
+   * The expected accumulated result in storeValue is 5,592,320 = 0x555500 [1]
+
+[1] Calculation for storeValue:
+Each iteration contributes i * (i+1) = i² + i, so:
+result = Σ(i=0 to 255) (i² + i) = Σi² + Σi
+Using the standard closed-form formulas for sums up to n=255:
+ - Σi (0→255) = 255×256/2 = 32,640
+ - Σi² (0→255) = 255×256×511/6 = 5,559,680
+ - result = 32,640 + 5,559,680 = 5,592,320 = 0x555500

--- a/academy/mac/mac_c/README.md
+++ b/academy/mac/mac_c/README.md
@@ -21,14 +21,9 @@ fits within the target device's Data RAM.
 
 ## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- PRU subsystem  | PRUSS0 - PRU0, PRU1 (AM62x); ICSS_G0 - PRU0, PRU1 (AM64x)
- Toolchain      | pru-cgt
- Board          | am62x-sk, am64x-evm
- Example folder | academy/mac/mac_c/
-
-For portability to other devices, see [academy/readme.md §Supported processors per-project](../../readme.md#supported-processors-per-project).
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
 
 ## Validated HW & SW
 

--- a/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example.projectspec file is for PRU projects written in C, or mixed C and assembly -->
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM62x_SK_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="MAC C"
+        name = "mac_c_am62x-sk_pruss0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU"
+        configurations="
+            Debug,
+            Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM62x_SK_EVM"
+        deviceCore="PRU_ICSS_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${OPEN_PRU_PATH}/source
+            -I${OPEN_PRU_PATH}/source/firmware/common
+            -I${OPEN_PRU_PATH}/source/include
+            -I${OPEN_PRU_PATH}/source/include/am62x
+            -DPRU0
+            -DSLICE0
+            -v3
+            -DSOC_AM62X
+            -O2
+        "
+        linkerBuildOptions="
+            -m=mac_c.${ConfigName}.map
+            --stack_size=0x100
+            --heap_size=0x100
+            -i${CG_TOOL_ROOT}/lib
+            -i${CG_TOOL_ROOT}/include
+            --library=libc.a
+            --diag_suppress=10063-D
+            --warn_sections
+            --reread_libs
+            --diag_warning=225
+            --ram_model
+        "
+
+        postBuildStep=""
+
+        description="MAC C FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM62x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM62x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,50 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := mac_c_am62x-sk_pruss0_pru0_fw
+
+# NOT SUPPORTED on AM62x
+# AM62x does not support initializing PRU cores from an MCU+ core
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+HEX_ARRAY_PREFIX := PRU0Firmware
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/mac/mac_c/firmware/am62x-sk/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Silicon version (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+PRU_VERSION := 3
+EXPECTED_DEVICE := am62x
+
+# Default values are defined in pru_rules.mak:
+#   - include paths (INCLUDE)
+#   - compiler flags (CFLAGS)
+#   - linker flags (LFLAGS)
+
+# Optional:
+# Pre-define here to override default value
+#   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+
+# pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
+include $(OPEN_PRU_PATH)/pru_rules.mak
+
+# Optional:
+# Append values to INCLUDE, CFLAGS, or LFLAGS here.
+# Values can be appended like this:
+# INCLUDE += --include_path=<value>
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+

--- a/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,16 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=mac_c_am62x-sk_pruss0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example.projectspec file is for PRU projects written in C, or mixed C and assembly -->
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM62x_SK_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="MAC C"
+        name = "mac_c_am62x-sk_pruss0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU"
+        configurations="
+            Debug,
+            Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM62x_SK_EVM"
+        deviceCore="PRU_ICSS_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${OPEN_PRU_PATH}/source
+            -I${OPEN_PRU_PATH}/source/firmware/common
+            -I${OPEN_PRU_PATH}/source/include
+            -I${OPEN_PRU_PATH}/source/include/am62x
+            -DPRU1
+            -DSLICE1
+            -v3
+            -DSOC_AM62X
+            -O2
+        "
+        linkerBuildOptions="
+            -m=mac_c.${ConfigName}.map
+            --stack_size=0x100
+            --heap_size=0x100
+            -i${CG_TOOL_ROOT}/lib
+            -i${CG_TOOL_ROOT}/include
+            --library=libc.a
+            --diag_suppress=10063-D
+            --warn_sections
+            --reread_libs
+            --diag_warning=225
+            --ram_model
+        "
+
+        postBuildStep=""
+
+        description="MAC C FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM62x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM62x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+	PRU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,50 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := mac_c_am62x-sk_pruss0_pru1_fw
+
+# NOT SUPPORTED on AM62x
+# AM62x does not support initializing PRU cores from an MCU+ core
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+HEX_ARRAY_PREFIX := PRU1Firmware
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/mac/mac_c/firmware/am62x-sk/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Silicon version (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+PRU_VERSION := 3
+EXPECTED_DEVICE := am62x
+
+# Default values are defined in pru_rules.mak:
+#   - include paths (INCLUDE)
+#   - compiler flags (CFLAGS)
+#   - linker flags (LFLAGS)
+
+# Optional:
+# Pre-define here to override default value
+#   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+
+# pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
+include $(OPEN_PRU_PATH)/pru_rules.mak
+
+# Optional:
+# Append values to INCLUDE, CFLAGS, or LFLAGS here.
+# Values can be appended like this:
+# INCLUDE += --include_path=<value>
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+

--- a/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/mac/mac_c/firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,16 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=mac_c_am62x-sk_pruss0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example.projectspec file is for PRU projects written in C, or mixed C and assembly -->
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="MAC C"
+        name = "mac_c_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${OPEN_PRU_PATH}/source
+            -I${OPEN_PRU_PATH}/source/firmware/common
+            -I${OPEN_PRU_PATH}/source/include
+            -I${OPEN_PRU_PATH}/source/include/am64x
+            -DPRU0
+            -DSLICE0
+            -v4
+            -DSOC_AM64X
+            -O2
+        "
+        linkerBuildOptions="
+            -m=mac_c.${ConfigName}.map
+            --stack_size=0x100
+            --heap_size=0x100
+            -i${CG_TOOL_ROOT}/lib
+            -i${CG_TOOL_ROOT}/include
+            --library=libc.a
+            --diag_suppress=10063-D
+            --warn_sections
+            --reread_libs
+            --diag_warning=225
+            --ram_model
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU0Firmware -o ../pru0_load_bin.h ${BuildArtifactFileBaseName}.out;
+        "
+
+        description="MAC C FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,99 @@
+/*
+ * AM64x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0; use only the first 4 KB for PRU0 and reserve
+	 * the second 4 KB for RTU0 and Tx_PRU0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1; reserved completely for Slice1 cores - PRU1,
+	 * RTU1 and Tx_PRU1; do not use for any Slice0 cores */
+	PRU1_DMEM_1	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU0_DMEM_0	: org = 0x00001000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00001800 len = 0x00000800
+	RTU1_DMEM_1	: org = 0x00003000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU0	: org = 0x0002A000 len = 0x0000004C	CREGISTER=10
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,48 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := mac_c_am64x-evm_icss_g0_pru0_fw
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+HEX_ARRAY_PREFIX := PRU0Firmware
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/mac/mac_c/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Silicon version (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+PRU_VERSION := 4
+EXPECTED_DEVICE := am64x
+
+# Default values are defined in pru_rules.mak:
+#   - include paths (INCLUDE)
+#   - compiler flags (CFLAGS)
+#   - linker flags (LFLAGS)
+
+# Optional:
+# Pre-define here to override default value
+#   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+
+# pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
+include $(OPEN_PRU_PATH)/pru_rules.mak
+
+# Optional:
+# Append values to INCLUDE, CFLAGS, or LFLAGS here.
+# Values can be appended like this:
+# INCLUDE += --include_path=<value>
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+

--- a/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,16 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=mac_c_am64x-evm_icss_g0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
+++ b/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example.projectspec file is for PRU projects written in C, or mixed C and assembly -->
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM64x_GP_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="MAC C"
+        name = "mac_c_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU"
+        configurations="
+                Debug,
+                Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM64x_GP_EVM"
+        deviceCore="ICSS_G0_PRU_1"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${OPEN_PRU_PATH}/source
+            -I${OPEN_PRU_PATH}/source/firmware/common
+            -I${OPEN_PRU_PATH}/source/include
+            -I${OPEN_PRU_PATH}/source/include/am64x
+            -DPRU1
+            -DSLICE1
+            -v4
+            -DSOC_AM64X
+            -O2
+        "
+        linkerBuildOptions="
+            -m=mac_c.${ConfigName}.map
+            --stack_size=0x100
+            --heap_size=0x100
+            -i${CG_TOOL_ROOT}/lib
+            -i${CG_TOOL_ROOT}/include
+            --library=libc.a
+            --diag_suppress=10063-D
+            --warn_sections
+            --reread_libs
+            --diag_warning=225
+            --ram_model
+        "
+
+        postBuildStep="
+            $(CG_TOOL_ROOT)/bin/hexpru --diag_wrap=off --array --array:name_prefix=PRU1Firmware -o ../pru1_load_bin.h ${BuildArtifactFileBaseName}.out;
+        "
+
+        description="MAC C FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
+++ b/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,100 @@
+/*
+ * AM64x_PRU1.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM64x PRU1 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 12 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00003000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 1; use only the first 4 KB for PRU1 and reserve
+	 * the second 4 KB for RTU1 and Tx_PRU1 */
+	PRU1_DMEM_1	: org = 0x00000000 len = 0x00001000	CREGISTER=24
+	/* 8 KB PRU Data RAM 0; reserved completely for Slice0 cores - PRU0,
+	 * RTU0 and Tx_PRU0; do not use for any Slice1 cores */
+	PRU0_DMEM_0	: org = 0x00002000 len = 0x00001000	CREGISTER=25
+	/* NOTE: Custom split of the second 4 KB of ICSS Data RAMs 0 and 1
+	 * split equally between the corresponding RTU and Tx_PRU cores in
+	 * each slice */
+	RTU1_DMEM_1	: org = 0x00001000 len = 0x00000800
+	TX_PRU1_DMEM_1	: org = 0x00001800 len = 0x00000800
+	RTU0_DMEM_0	: org = 0x00003000 len = 0x00000800
+	TX_PRU0_DMEM_0	: org = 0x00003800 len = 0x00000800
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 64 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00010000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* XXX: PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	MII_G_RT	: org = 0x00033000 len = 0x00000F44	CREGISTER=9
+	TM_CFG_PRU1	: org = 0x0002A200 len = 0x0000004C	CREGISTER=10
+	PRU1_CTRL	: org = 0x00024000 len = 0x00000030	CREGISTER=11
+
+	PA_STATS_QRAM	: org = 0x00027000 len = 0x00001000	CREGISTER=12
+	PA_STATS_CRAM	: org = 0x0002C000 len = 0x00001000	CREGISTER=13
+	MII_MDIO	: org = 0x00032400 len = 0x00000088	CREGISTER=21
+	PRU_RTU_RAT1	: org = 0x00009000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+	MII_RT		: org = 0x00032000 len = 0x00000070	CREGISTER=27
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD14		: org = 0x00024800 len = 0x00000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x00000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x00000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x00000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x00000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x00000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x00000100	CREGISTER=20
+	RSVD23		: org = 0xC0000000 len = 0x00000100	CREGISTER=23
+	/* Random length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU1_DMEM_1, PAGE 1
+	.bss		>  PRU1_DMEM_1, PAGE 1
+	.cio		>  PRU1_DMEM_1, PAGE 1
+	.data		>  PRU1_DMEM_1, PAGE 1
+	.switch		>  PRU1_DMEM_1, PAGE 1
+	.sysmem		>  PRU1_DMEM_1, PAGE 1
+	.cinit		>  PRU1_DMEM_1, PAGE 1
+	.rodata		>  PRU1_DMEM_1, PAGE 1
+	.rofardata	>  PRU1_DMEM_1, PAGE 1
+	.farbss		>  PRU1_DMEM_1, PAGE 1
+	.fardata	>  PRU1_DMEM_1, PAGE 1
+}

--- a/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
+++ b/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile
@@ -1,0 +1,48 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := mac_c_am64x-evm_icss_g0_pru1_fw
+
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru1_load_bin.h
+HEX_ARRAY_PREFIX := PRU1Firmware
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/mac/mac_c/firmware/am64x-evm/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Silicon version (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+PRU_VERSION := 4
+EXPECTED_DEVICE := am64x
+
+# Default values are defined in pru_rules.mak:
+#   - include paths (INCLUDE)
+#   - compiler flags (CFLAGS)
+#   - linker flags (LFLAGS)
+
+# Optional:
+# Pre-define here to override default value
+#   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+
+# pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
+include $(OPEN_PRU_PATH)/pru_rules.mak
+
+# Optional:
+# Append values to INCLUDE, CFLAGS, or LFLAGS here.
+# Values can be appended like this:
+# INCLUDE += --include_path=<value>
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+

--- a/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/mac/mac_c/firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,16 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=mac_c_am64x-evm_icss_g0_pru1_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/mac/mac_c/firmware/main.c
+++ b/academy/mac/mac_c/firmware/main.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2021 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *	* Redistributions of source code must retain the above copyright
+ *	  notice, this list of conditions and the following disclaimer.
+ *
+ *	* Redistributions in binary form must reproduce the above copyright
+ *	  notice, this list of conditions and the following disclaimer in the
+ *	  documentation and/or other materials provided with the
+ *	  distribution.
+ *
+ *	* Neither the name of Texas Instruments Incorporated nor the names of
+ *	  its contributors may be used to endorse or promote products derived
+ *	  from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// ***************************************
+// *    Global Structure Definitions     *
+// ***************************************
+
+#include <stdint.h>
+
+
+/* R31 is used to generate the "I'm done" back to the ARM */
+volatile register uint8_t __R31;
+
+/* Accessing the operands structure within the multiplyParams structure
+ * forces the compiler to pair the registers together */
+typedef struct {
+	uint32_t op1;
+	uint32_t op2;
+} operands;
+
+#define NUMMACS 256
+
+/*
+ * Structure buf is pretty big: uint32 * 2 * 256 = 2kB, or 0x800 memory.
+ * Make sure that there is enough Data RAM for your program. This example
+ * allocates space for buf in .bss (uninitialized near data section).
+ * After you build the example, you can verify the amount of Data RAM the
+ * example uses by inspecting the .map file in the outputs folder.
+ * The .map file for the MAC example tells us:
+ * MEMORY CONFIGURATION --> PRUx_DMEMx: 0x900 memory is used
+ * SECTION ALLOCATION MAP: .bss uses 0x800 (this is buf), .stack uses 0x100
+ *
+ * To modify the size of the stack, edit Makefile > STACK_SIZE.
+ *
+ * Reference "PRU Optimizing C/C++ Compiler User's Guide", section "Dynamic
+ * Memory Allocation" if you want to allocate large arrays from the heap instead
+ * of the .bss section.
+ */
+operands buf[NUMMACS];
+
+/* Need to create a while loop inside main to wait for interrupt from host.
+ * The interrupt will signify that a buffer of data has been passed and is
+ * ready for MAC processing. This will be passed by rpmsg driver.
+ */
+int main(void)
+{
+	uint32_t i;
+	uint16_t numMacs = NUMMACS; // Arbitrary number
+	uint64_t result = 0;
+	volatile uint64_t storeValue = 0;
+
+	/* Dummy data set */
+	for (i = 0; i < numMacs; i++) {
+		buf[i].op1 = i;
+		buf[i].op2 = i+1;
+	}
+
+	/* Perform numMacs MAC operations */
+	for (i = 0; i < numMacs; i++) {
+		result += (uint64_t)buf[i].op1 * (uint64_t)buf[i].op2;
+	}
+
+	storeValue = result;
+
+	/* Nothing to do so halt */
+	__halt();
+}

--- a/academy/mac/mac_c/firmware/main.c
+++ b/academy/mac/mac_c/firmware/main.c
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (C) 2021 Texas Instruments Incorporated - http://www.ti.com/
+ */
+
+// ***************************************
+// *    Global Structure Definitions     *
+// ***************************************
+
+#include <stdint.h>
+
+
+/* R31 is used to generate the "I'm done" back to the ARM */
+volatile register uint8_t __R31;
+
+/* Accessing the operands structure within the multiplyParams structure
+ * forces the compiler to pair the registers together */
+typedef struct {
+	uint32_t op1;
+	uint32_t op2;
+} operands;
+
+#define NUMMACS 256
+
+/*
+ * Structure buf is pretty big: uint32 * 2 * 256 = 2kB, or 0x800 memory.
+ * Make sure that there is enough Data RAM for your program. This example
+ * allocates space for buf in .bss (uninitialized near data section).
+ * After you build the example, you can verify the amount of Data RAM the
+ * example uses by inspecting the .map file in the outputs folder.
+ * The .map file for the MAC example tells us:
+ * MEMORY CONFIGURATION --> PRUx_DMEMx: 0x900 memory is used
+ * SECTION ALLOCATION MAP: .bss uses 0x800 (this is buf), .stack uses 0x100
+ *
+ * To modify the size of the stack, edit Makefile > STACK_SIZE.
+ *
+ * Reference "PRU Optimizing C/C++ Compiler User's Guide", section "Dynamic
+ * Memory Allocation" if you want to allocate large arrays from the heap instead
+ * of the .bss section.
+ */
+operands buf[NUMMACS];
+
+/* Need to create a while loop inside main to wait for interrupt from host.
+ * The interrupt will signify that a buffer of data has been passed and is
+ * ready for MAC processing. This will be passed by rpmsg driver.
+ */
+int main(void)
+{
+	uint32_t i;
+	uint16_t numMacs = NUMMACS; // Arbitrary number
+	uint64_t result = 0;
+	volatile uint64_t storeValue = 0;
+
+	/* Dummy data set */
+	for (i = 0; i < numMacs; i++) {
+		buf[i].op1 = i;
+		buf[i].op2 = i+1;
+	}
+
+	/* Perform numMacs MAC operations */
+	for (i = 0; i < numMacs; i++) {
+		result += (uint64_t)buf[i].op1 * (uint64_t)buf[i].op2;
+	}
+
+	/*
+	 * NOTE!
+	 * 
+	 * This C code does NOT use the PRU subsystem's MAC hardware
+	 * accelerator. Instead, the multiplication is converted by the C
+	 * compiler into a series of additions in the generated assembly file.
+	 * Test by adding --keep_asm to the compiler flags as per the PRU
+	 * Getting Started Labs, and searching the generated main.asm file for
+	 * the line number with the multiply.
+	 * 
+	 * For an example of using assembly code to use the MAC hardware
+	 * accelerator, refer to academy/mac/mac.
+	 * 
+	 * For an example of writing mixed C and assembly code, refer to the
+	 * PRU Getting Started Labs under academy/getting_started_labs.
+	 */
+
+	/*
+	 * FIXME: research, is there a way to call MAC hardware accelerator
+	 * directly from C code?
+	 */
+
+	storeValue = result;
+
+	/* Nothing to do so halt */
+	__halt();
+}

--- a/academy/mac/mac_c/makefile
+++ b/academy/mac/mac_c/makefile
@@ -1,0 +1,106 @@
+include ../../../imports.mak
+
+#######################
+# project information #
+#######################
+
+PROJECT_NAME := mac_c
+SUPPORTED_PROCESSORS := am62x am64x
+# Does the PRU code have dependencies outside of the open-pru repo?
+PRU_DEPENDENCIES :=
+# Use NON_PRU_DEPENDENCIES to select which makefiles to call for non-PRU cores
+NON_PRU_DEPENDENCIES :=
+
+###################
+# Prebuild checks #
+###################
+BUILD_PROJECT := y
+DEVICE_NON_PRU :=
+
+# Only build project if $(DEVICE) is in $(SUPPORTED_PROCESSORS)
+ifeq (,$(findstring $(DEVICE),$(SUPPORTED_PROCESSORS)))
+BUILD_PROJECT := n
+MESSAGE := Project $(PROJECT_NAME) does not have a build option for $(DEVICE)
+endif
+
+# Only build project if PRU dependencies exist
+ifneq (,$(PRU_DEPENDENCIES))
+# MCU+ SDK dependency?
+ifeq (mcuplus,$(findstring mcuplus,$(PRU_DEPENDENCIES)))
+ifneq ($(BUILD_MCUPLUS),y)
+BUILD_PROJECT := n
+MESSAGE ?= Project $(PROJECT_NAME) depends on MCU+ SDK, but BUILD_MCUPLUS != y.
+endif
+endif
+# Additional PRU dependency checks go here. For example:
+#ifeq (dependency,$(findstring dependency,$(PRU_DEPENDENCIES)))
+#if (dependency check fails)
+#BUILD_PROJECT := n
+#MESSAGE ?= Project $(PROJECT_NAME) depends on dependency, but dependency does not exist.
+#endif
+#endif
+endif
+
+# Only build non-PRU code if the non-PRU code is enabled in imports.mak
+ifeq ($(BUILD_MCUPLUS),y)
+ifeq (mcuplus,$(findstring mcuplus,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_mcuplus
+endif
+endif
+ifeq ($(BUILD_LINUX),y)
+ifeq (linux,$(findstring linux,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_linux
+endif
+endif
+
+###########################
+# Make and clean commands #
+###########################
+
+ifeq ($(BUILD_PROJECT),y)
+# "make" or "make all" builds projects that match $(DEVICE) set in imports.mak
+# "make" builds PRU firmware first, then host (non-PRU) code
+all: MESSAGE = "Building $(PROJECT_NAME) for $(DEVICE)"
+all: pre_build_message
+	$(MAKE) pru
+	$(MAKE) host
+
+# "make pru" builds only PRU firmware for $(DEVICE)
+pru: ARGUMENTS_PRU = all
+pru: $(DEVICE)
+
+# "make host" builds only host (non-PRU) code for $(DEVICE)
+host: ARGUMENTS_MCUPLUS = all
+host: $(DEVICE_NON_PRU)
+
+# "make clean" cleans projects that match $(DEVICE) set in imports.mak
+clean: ARGUMENTS_PRU = clean
+clean: ARGUMENTS_MCUPLUS = scrub
+clean: MESSAGE = "Cleaning $(PROJECT_NAME) for $(DEVICE)"
+clean: pre_build_message $(DEVICE) $(DEVICE_NON_PRU)
+
+else
+# if a prebuild check failed, print message and exit
+all clean pru host: pre_build_message
+endif
+
+pre_build_message:
+	@echo $(MESSAGE)
+
+######################
+# Target definitions #
+######################
+
+# provide target definitions for each supported processor
+# PRU firmware should be built before any RTOS code that includes it
+am62x:
+# am62x-sk
+	$(MAKE) -C firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am62x-sk/pruss0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+am64x:
+# am64x-evm
+	$(MAKE) -C firmware/am64x-evm/icss_g0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am64x-evm/icss_g0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+.PHONY: all clean pru host pre_build_message $(DEVICE) $(DEVICE_NON_PRU) $(SUPPORTED_PROCESSORS)

--- a/academy/mac/mac_multiply/readme.md
+++ b/academy/mac/mac_multiply/readme.md
@@ -4,10 +4,6 @@
 
 This example acts as a basic demonstration of the usage of MAC module in Multiply-Only mode in ICSSM PRU.
 
-## Overview 
-
-Here's the Overview section for the MAC (Multiply Only Mode) example README:
-
 ## Overview
 
 This example demonstrates the usage of PRU's MAC (Multiply and Accumulate) broadside accelerator in its Multiply Only mode. While the MAC module is capable of both multiplication and accumulation operations, this mode specifically showcases its ability to perform high-speed unsigned multiplications without accumulation, making it ideal for applications requiring quick multiplication operations.
@@ -22,12 +18,27 @@ The MAC module performs the multiplication without any accumulation, demonstrati
 
 This simple demonstration shows how the PRU's hardware acceleration can be utilized for basic arithmetic operations with improved performance compared to software-based multiplication.
 
-# Supported Combinations
+## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSM          | ICSSM0 - PRU0, PRU1; ICSSM1 (only in am261x) - PRU0, PRU1
- Toolchain      | pru-cgt
- Board          | am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp
- Example folder | academy/mac/mac_multiply
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+
+## Steps to Run the Example
+
+1. Build and run the PRU firmware.
+2. After the firmware finishes running, inspect the PRU register values:
+   - R26: lower 32 bits of the multiplication result; expected `0x4E2`
+     (1250 decimal = 50 × 25)
+   - R27: upper 32 bits; expected `0x00`
 

--- a/academy/mac/mac_multiply/readme.md
+++ b/academy/mac/mac_multiply/readme.md
@@ -30,9 +30,9 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am261x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263px   | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
-| am263x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am261x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263px   | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
+| am263x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
 
 ## Steps to Run the Example
 

--- a/academy/makefile
+++ b/academy/makefile
@@ -5,7 +5,8 @@ SUBDIRS := \
     getting_started_labs \
     gpio/gpio_toggle \
     intc/intc_mcu \
-    mac/mac mac/mac_multiply
+    mac/mac mac/mac_multiply mac/mac_c \
+    uart/uart_loopback
 
 # "make" or "make all" builds projects that match $(DEVICE) set in imports.mak
 all: ARGUMENTS = all

--- a/academy/readme.md
+++ b/academy/readme.md
@@ -44,10 +44,16 @@ intc/intc_mcu
   between the PRU core and an MCU+ core
 
 mac/mac
-* How to use the MAC module in Multiply and Accumulate mode
+* How to use the MAC module in Multiply and Accumulate mode (assembly)
+
+mac/mac_c
+* How to use the MAC module in Multiply and Accumulate mode (C)
 
 mac/mac_multiply
-* How to use the MAC module in Multiply-Only mode
+* How to use the MAC module in Multiply-Only mode (assembly)
+
+uart/uart_loopback
+* Loopback example with the PRU hardware UART peripheral
 
 ## Supported processors per-project
 
@@ -82,4 +88,6 @@ For more information about the PRU features on each processor, refer to app note
 | gpio/gpio_toggle     | Yport  | Y      | Y       | Y      | N-sw  | Yport |
 | intc/intc_mcu        | Yport  | Y      | Y       | Y      | N-sw  | Yport |
 | mac/mac              | Yport  | Y      | Y       | Y      | Yport | Yport |
+| mac/mac_c            | Yport  | Yport  | Yport   | Yport  | Y     | Y     |
 | mac/mac_multiply     | Yport  | Y      | Y       | Y      | Yport | Yport |
+| uart/uart_loopback   | Yport  | Yport  | Yport   | Yport  | Y     | Yport |

--- a/academy/readme.md
+++ b/academy/readme.md
@@ -44,10 +44,16 @@ intc/intc_mcu
   between the PRU core and an MCU+ core
 
 mac/mac
-* How to use the MAC module in Multiply and Accumulate mode
+* How to use the MAC module in Multiply and Accumulate mode (assembly)
+
+mac/mac_c
+* How to do MAC without using the hardware MAC accelerator (C)
 
 mac/mac_multiply
-* How to use the MAC module in Multiply-Only mode
+* How to use the MAC module in Multiply-Only mode (assembly)
+
+uart/uart_loopback
+* Loopback example with the PRU hardware UART peripheral
 
 ## Supported processors per-project
 
@@ -82,4 +88,6 @@ For more information about the PRU features on each processor, refer to app note
 | gpio/gpio_toggle     | Yport  | Y      | Y       | Y      | N-sw  | Yport |
 | intc/intc_mcu        | Yport  | Y      | Y       | Y      | N-sw  | Yport |
 | mac/mac              | Yport  | Y      | Y       | Y      | Yport | Yport |
+| mac/mac_c            | Yport  | Yport  | Yport   | Yport  | Y     | Y     |
 | mac/mac_multiply     | Yport  | Y      | Y       | Y      | Yport | Yport |
+| uart/uart_loopback   | Yport  | Yport  | Yport   | Yport  | Y     | Yport |

--- a/academy/uart/uart_loopback/README.md
+++ b/academy/uart/uart_loopback/README.md
@@ -1,0 +1,47 @@
+# UART Loopback
+
+## Overview
+
+This example demonstrates the PRU UART peripheral by configuring it at 115200
+baud in loopback mode, transmitting 6 characters ("Hello!"), receiving them
+back through the internal loopback path, and halting. No external wiring is
+required because loopback mode connects the transmit output to the receive
+input inside the UART block.
+
+The example is adapted from the PRU Software Support Package (PSSP)
+`PRU_Hardware_UART` example.
+
+## Supported Combinations
+
+ Parameter      | Value
+ ---------------|-----------
+ PRU subsystem  | PRUSS0 - PRU0
+ Toolchain      | pru-cgt
+ Board          | am62x-sk
+ Example folder | academy/uart/uart_loopback/
+
+For portability to other devices, see [academy/readme.md §Supported processors per-project](../../readme.md#supported-processors-per-project).
+
+## Hardware
+
+No external connections are required. The UART operates in internal loopback
+mode. To route UART signals to physical pins, disable loopback (clear
+`CT_UART.MCTR`) and configure the appropriate pinmux before running the
+firmware.
+
+## Validated HW & SW
+
+- Board: SK-AM62B
+- TI PRU Code Generation Tools (CGT) v2.3.3
+- Code Composer Studio 20.x
+- OpenPRU v2026.01.00
+
+## Running and Validating
+
+1. Load the built ELF onto the AM62x-SK PRU0 core using CCS. Refer to the **PRU
+   Getting Started Labs > Lab 4: How to Initialize the PRU** for details.
+2. Run the PRU core.
+3. Halt execution at `__halt()`.
+4. Inspect the `buffer` array. Refer to the **PRU Getting Started Labs >
+   Lab 5: How to debug PRU firmware** for details.
+   * The first 6 bytes should contain `0x48 0x65 0x6C 0x6C 0x6F 0x21` ("Hello!").

--- a/academy/uart/uart_loopback/README.md
+++ b/academy/uart/uart_loopback/README.md
@@ -1,5 +1,10 @@
 # UART Loopback
 
+## Introduction
+
+This example demonstrates the PRU UART peripheral by configuring it in
+loopback mode and exercising a transmit/receive cycle.
+
 ## Overview
 
 This example demonstrates the PRU UART peripheral by configuring it at 115200
@@ -13,14 +18,9 @@ The example is adapted from the PRU Software Support Package (PSSP)
 
 ## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- PRU subsystem  | PRUSS0 - PRU0
- Toolchain      | pru-cgt
- Board          | am62x-sk
- Example folder | academy/uart/uart_loopback/
-
-For portability to other devices, see [academy/readme.md §Supported processors per-project](../../readme.md#supported-processors-per-project).
+Refer to open-pru/academy/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
 
 ## Hardware
 

--- a/academy/uart/uart_loopback/README.md
+++ b/academy/uart/uart_loopback/README.md
@@ -1,0 +1,46 @@
+# UART Loopback
+
+## Overview
+
+This example demonstrates the PRU UART peripheral by configuring it at 115200
+baud in loopback mode, transmitting 6 characters ("Hello!"), receiving them
+back through the internal loopback path, and halting. No external wiring is
+required because loopback mode connects the transmit output to the receive
+input inside the UART block.
+
+The example is adapted from the PRU Software Support Package (PSSP)
+`PRU_Hardware_UART` example.
+
+## Supported Combinations
+
+ Parameter      | Value
+ ---------------|-----------
+ PRU subsystem  | PRUSS0 - PRU0
+ Toolchain      | pru-cgt
+ Board          | am62x-sk
+ Example folder | academy/uart/uart_loopback/
+
+For portability to other devices, see [academy/readme.md §Supported processors per-project](../../readme.md#supported-processors-per-project).
+
+## Hardware
+
+No external connections are required. The UART operates in internal loopback
+mode. To route UART signals to physical pins, disable loopback (clear
+`CT_UART.MCTR`) and configure the appropriate pinmux before running the
+firmware.
+
+## Validated HW & SW
+
+| Processor | Hardware | Software                                                                  |
+|-----------|----------|---------------------------------------------------------------------------|
+| AM62x     | SK-AM62B | TI PRU CGT v2.3.3, CCS 12.7, OpenPRU v2026.01.00        |
+
+## Running and Validating
+
+1. Load the built ELF onto the AM62x-SK PRU0 core using CCS. Refer to the **PRU
+   Getting Started Labs > Lab 4: How to Initialize the PRU** for details.
+2. Run the PRU core.
+3. Halt execution at `__halt()`.
+4. Inspect the `buffer` array. Refer to the **PRU Getting Started Labs >
+   Lab 5: How to debug PRU firmware** for details.
+   * The first 6 bytes should contain `0x48 0x65 0x6C 0x6C 0x6F 0x21` ("Hello!").

--- a/academy/uart/uart_loopback/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
+++ b/academy/uart/uart_loopback/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/example.projectspec
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example.projectspec file is for PRU projects written in C, or mixed C and assembly -->
+<projectSpec>
+    <applicability>
+        <when>
+            <context
+                deviceFamily="PRU"
+                deviceId="AM62x_SK_EVM"
+            />
+        </when>
+    </applicability>
+
+    <project
+        title="UART Loopback"
+        name = "uart_loopback_am62x-sk_pruss0_pru0_fw_ti-pru-cgt"
+        products="com.ti.OPEN_PRU"
+        configurations="
+            Debug,
+            Release,
+        "
+        connection="TIXDS110_Connection.xml"
+        toolChain="TI"
+        cgtVersion="2.3.3"
+        device="AM62x_SK_EVM"
+        deviceCore="PRU_ICSS_PRU_0"
+        ignoreDefaultDeviceSettings="true"
+        ignoreDefaultCCSSettings="true"
+        endianness="little"
+        outputFormat="ELF"
+        outputType="executable"
+
+        compilerBuildOptions="
+            -I${CG_TOOL_ROOT}/include
+            -I${OPEN_PRU_PATH}/source
+            -I${OPEN_PRU_PATH}/source/firmware/common
+            -I${OPEN_PRU_PATH}/source/include
+            -I${OPEN_PRU_PATH}/source/include/am62x
+            -DPRU0
+            -DSLICE0
+            -v3
+            -DSOC_AM62X
+            -O2
+        "
+        linkerBuildOptions="
+            -m=uart_loopback.${ConfigName}.map
+            --stack_size=0x100
+            --heap_size=0x100
+            -i${CG_TOOL_ROOT}/lib
+            -i${CG_TOOL_ROOT}/include
+            --library=libc.a
+            --diag_suppress=10063-D
+            --warn_sections
+            --reread_libs
+            --diag_warning=225
+            --ram_model
+        "
+
+        postBuildStep=""
+
+        description="UART loopback FW project">
+
+        <configuration name="Debug"
+            compilerBuildOptions="
+                -D_DEBUG_=1
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <configuration name="Release"
+            compilerBuildOptions="
+            "
+            linkerBuildOptions="
+            "
+        ></configuration>
+        <pathVariable name="OPEN_PRU_PATH" path="${COM_TI_OPEN_PRU_INSTALL_DIR}" scope="project" />
+        <file path="../../../main.c" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+        <file path="./linker.cmd" openOnCreation="false" excludeFromBuild="false" action="copy">
+        </file>
+    </project>
+</projectSpec>

--- a/academy/uart/uart_loopback/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/linker.cmd
+++ b/academy/uart/uart_loopback/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/linker.cmd
@@ -1,0 +1,90 @@
+/*
+ * AM62x_PRU0.cmd
+ *
+ * Example Linker command file for linking programs built with the C compiler
+ * on AM62x PRU0 cores
+ */
+
+-cr		/* Link using C conventions */
+
+/* Specify the System Memory Map */
+MEMORY
+{
+      PAGE 0:
+	/* 16 KB PRU Instruction RAM */
+	PRU_IMEM	: org = 0x00000000 len = 0x00004000
+
+      PAGE 1:
+	/* Data RAMs */
+	/* 8 KB PRU Data RAM 0 */
+	PRU0_DMEM_0	: org = 0x00000000 len = 0x00002000	CREGISTER=24
+	/* 8 KB PRU Data RAM 1 */
+	PRU1_DMEM_1	: org = 0x00002000 len = 0x00002000	CREGISTER=25
+
+      PAGE 2:
+	/* C28 needs to be programmed to point to SHAREDMEM, default is 0 */
+	/* 32 KB PRU Shared RAM */
+	PRU_SHAREDMEM	: org = 0x00010000 len = 0x00008000	CREGISTER=28
+
+	/* Internal Peripherals */
+	/* NOTE: Use full INTC length instead of 0x200 to match the pruIntc
+	 * structure definition in pru_intc.h, ignoring the second Constant
+	 * Register #6 that starts at 0x200 offset within INTC */
+	PRU_INTC	: org = 0x00020000 len = 0x00001504	CREGISTER=0
+	PRU_IEP1	: org = 0x0002F000 len = 0x00000100	CREGISTER=1
+	PRU_IEP1_0x100	: org = 0x0002F100 len = 0x0000021C	CREGISTER=2
+	PRU_ECAP	: org = 0x00030000 len = 0x00000060	CREGISTER=3
+	PRU_CFG		: org = 0x00026000 len = 0x00000100	CREGISTER=4
+	PRU_CFG_0x100	: org = 0x00026100 len = 0x00000098	CREGISTER=5
+	/* PRU_INTC_0x200 is part of INTC space, and is therefore commented
+	 * out as it conflicts with PRU_INTC size above. To use PRU_INTC_0x200,
+	 * split up the pruIntc structure and CT_INTC variable in
+	 * source/include/PROCESSOR/pru_intc.h */
+	/*PRU_INTC_0x200: org = 0x00020200 len = 0x00001304	CREGISTER=6*/
+	PRU_UART	: org = 0x00028000 len = 0x00000038	CREGISTER=7
+	PRU_IEP0_0x100	: org = 0x0002E100 len = 0x0000021C	CREGISTER=8
+	PRU0_CTRL	: org = 0x00022000 len = 0x00000030	CREGISTER=11
+	PRU_RAT0	: org = 0x00008000 len = 0x00000854	CREGISTER=22
+	PRU_IEP0	: org = 0x0002E000 len = 0x00000100	CREGISTER=26
+
+	/* External Regions */
+	/* Random length 0x100 assigned to the below regions */
+	RSVD9		: org = 0x00033000 len = 0x0000100	CREGISTER=9
+	RSVD10		: org = 0x0002A000 len = 0x0000100	CREGISTER=10
+	RSVD12		: org = 0x00027000 len = 0x0000100	CREGISTER=12
+	RSVD13		: org = 0x0002C000 len = 0x0000100	CREGISTER=13
+	RSVD14		: org = 0x00024800 len = 0x0000100	CREGISTER=14
+	RSVD15		: org = 0x60000000 len = 0x0000100	CREGISTER=15
+	RSVD16		: org = 0x70000000 len = 0x0000100	CREGISTER=16
+	RSVD17		: org = 0x80000000 len = 0x0000100	CREGISTER=17
+	RSVD18		: org = 0x90000000 len = 0x0000100	CREGISTER=18
+	RSVD19		: org = 0xA0000000 len = 0x0000100	CREGISTER=19
+	RSVD20		: org = 0xB0000000 len = 0x0000100	CREGISTER=20
+	RSVD21		: org = 0x00032400 len = 0x0000100	CREGISTER=21
+	RSVD23		: org = 0xC0000000 len = 0x0000100	CREGISTER=23
+	RSVD27		: org = 0x00032000 len = 0x0000100	CREGISTER=27
+	/* length 0x10000 (max len value) assigned to programmable C29-31*/
+	RSVD29		: org = 0xD0000000 len = 0x00010000	CREGISTER=29
+	RSVD30		: org = 0xE0000000 len = 0x00010000	CREGISTER=30
+	RSVD31		: org = 0xF0000000 len = 0x00010000	CREGISTER=31
+}
+
+/* Specify the sections allocation into memory */
+SECTIONS {
+	/* Forces _c_int00 to the start of PRU IRAM. Not necessary when loading
+	   an ELF file, but useful when loading a binary */
+	.text:_c_int00*	>  0x0, PAGE 0
+
+	.text		>  PRU_IMEM, PAGE 0
+	.stack		>  PRU0_DMEM_0, PAGE 1
+	.bss		>  PRU0_DMEM_0, PAGE 1
+	.cio		>  PRU0_DMEM_0, PAGE 1
+	.data		>  PRU0_DMEM_0, PAGE 1
+	.switch		>  PRU0_DMEM_0, PAGE 1
+	.sysmem		>  PRU0_DMEM_0, PAGE 1
+	.cinit		>  PRU0_DMEM_0, PAGE 1
+	.rodata		>  PRU0_DMEM_0, PAGE 1
+	.rofardata	>  PRU0_DMEM_0, PAGE 1
+	.farbss		>  PRU0_DMEM_0, PAGE 1
+	.fardata	>  PRU0_DMEM_0, PAGE 1
+}

--- a/academy/uart/uart_loopback/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
+++ b/academy/uart/uart_loopback/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile
@@ -1,0 +1,50 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+# Define build outputs
+OUTPUT_NAME := uart_loopback_am62x-sk_pruss0_pru0_fw
+
+# NOT SUPPORTED on AM62x
+# AM62x does not support initializing PRU cores from an MCU+ core
+# MCU+ projects: rename & move hex array output
+MCU_HEX_NAME := pru0_load_bin.h
+HEX_ARRAY_PREFIX := PRU0Firmware
+MCU_HEX_PATH := $(OPEN_PRU_PATH)/academy/uart/uart_loopback/firmware/am62x-sk/$(MCU_HEX_NAME)
+
+# which directories to search for assembly & C source files?
+FILES_PATH := .. ../../.. .
+
+# Linker command file
+COMMAND_FILES := linker.cmd
+
+# Silicon version (3: PRUSS, PRU-ICSS; 4: PRU_ICSSG)
+PRU_VERSION := 3
+EXPECTED_DEVICE := am62x
+
+# Default values are defined in pru_rules.mak:
+#   - include paths (INCLUDE)
+#   - compiler flags (CFLAGS)
+#   - linker flags (LFLAGS)
+
+# Optional:
+# Pre-define here to override default value
+#   OPT_LEVEL, STACK_SIZE, HEAP_SIZE, or ENTRY_POINT
+
+# pru_rules.mak has shared settings for all PRU/RTU/TX_PRU core makefiles
+include $(OPEN_PRU_PATH)/pru_rules.mak
+
+# Optional:
+# Append values to INCLUDE, CFLAGS, or LFLAGS here.
+# Values can be appended like this:
+# INCLUDE += --include_path=<value>
+
+# Defines (pass instance specific definitions to the program)
+# see --define or -D in 'PRU Optimizing C/C++ Compiler User's Guide'
+# For example, to define PRU0, ICSSG1, SOC_AM243X, and set _DEBUG_=1:
+# -DPRU0 -DICSSG1 --define=SOC_AM243X -D_DEBUG_=1
+DFLAGS :=
+
+# Libraries
+# see --library in 'PRU Optimizing C/C++ Compiler User's Guide'
+LIBS :=
+

--- a/academy/uart/uart_loopback/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile_projectspec
+++ b/academy/uart/uart_loopback/firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt/makefile_projectspec
@@ -1,0 +1,16 @@
+export OPEN_PRU_PATH?=$(abspath ../../../../../../..)
+include $(OPEN_PRU_PATH)/imports.mak
+
+PROFILE?=Release
+
+PROJECT_NAME=uart_loopback_am62x-sk_pruss0_pru0_fw_ti-pru-cgt
+
+all:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE)
+
+clean:
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectBuild -ccs.projects $(PROJECT_NAME) -ccs.configuration $(PROFILE) -ccs.clean
+
+export:
+	$(MKDIR) $(OPEN_PRU_PATH)/ccs_projects
+	$(CCS_ECLIPSE) -noSplash -data $(OPEN_PRU_PATH)/ccs_projects -application com.ti.ccstudio.apps.projectCreate -ccs.projectSpec example.projectspec -ccs.overwrite full

--- a/academy/uart/uart_loopback/firmware/main.c
+++ b/academy/uart/uart_loopback/firmware/main.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2024-2024 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *	* Redistributions of source code must retain the above copyright
+ *	  notice, this list of conditions and the following disclaimer.
+ *
+ *	* Redistributions in binary form must reproduce the above copyright
+ *	  notice, this list of conditions and the following disclaimer in the
+ *	  documentation and/or other materials provided with the
+ *	  distribution.
+ *
+ *	* Neither the name of Texas Instruments Incorporated nor the names of
+ *	  its contributors may be used to endorse or promote products derived
+ *	  from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <pru_uart.h>
+
+/* The FIFO size on the PRU UART is 16 bytes; however, we are (arbitrarily)
+ * only going to send 8 at a time */
+#define FIFO_SIZE	16
+#define MAX_CHARS	8
+
+/* This hostBuffer structure is temporary but stores a data buffer */
+struct {
+	uint8_t msg; // Not used today
+	uint8_t data[FIFO_SIZE];
+} hostBuffer;
+
+/* Making this buffer global will force the received data into memory */
+uint8_t buffer[MAX_CHARS];
+
+int main(void)
+{
+	uint8_t tx;
+	uint8_t cnt;
+
+	/* FIXME: If modifying this to send data through the pins then PinMuxing
+	 * needs to be taken care of prior to running this code.
+	 * This is usually done via a GEL file in CCS or by the Linux driver */
+
+	/*
+	 * NOTE!!! As of AM62x TRM Rev B:
+	 *
+	 * - Definitions of PRU UART register field descriptions are missing
+	 *
+	 *   - The PRU UART hardware in AM335x & AM62x is EXACTLY identical.
+	 *     Thus, we can reference the AM335x TRM instead
+	 *
+	 *   - Detailed register field descriptions can be found in the AM335x
+	 *     TRM, Section PRU > Registers > PRU_ICSS_UART Registers
+	 *
+	 * - PRU UART register bitfields are wrong, for the registers where
+	 *   multiple registers share the same base address (RBR, THR, IIR, FCR)
+	 *
+	 *   - Refer to AM335x TRM for correct bitfields
+	 */
+
+	/*** INITIALIZATION ***/
+
+	/* Set up UART to function at 115200 baud - DLL divisor is 104 at 16x oversample
+	 * 192MHz / 104 / 16 = ~115200 */
+	CT_UART.DIVLSB = 104;
+	CT_UART.DIVMSB = 0;
+	CT_UART.MODE = 0x0;
+
+	/* Enable Interrupts in UART module. This allows the main thread to poll for
+	 * Receive Data Available and Transmit Holding Register Empty */
+	CT_UART.INT_EN = 0x7;
+
+	/* If FIFOs are to be used, select desired trigger level and enable
+	 * FIFOs by writing to FCR. FIFOEN bit in FCR must be set first before
+	 * other bits are configured */
+	CT_UART.FCR_bit.FIFOEN = 1;
+
+	/* Enable FIFOs */
+	CT_UART.FCR_bit.DMAMODE1 = 1;
+	/* RXFIFTL = 0x0 = 1-byte RX FIFO trigger */
+	/* Alternative: 8-byte RX FIFO trigger */
+	// CT_UART.FCR_bit.RXFIFTL = 0x2;
+
+	/* flush the FIFOs */
+	CT_UART.FCR_bit.TXCLR = 1;
+	CT_UART.FCR_bit.RXCLR = 1;
+
+	/* Choose desired protocol settings by writing to LCR */
+	/* 8-bit word, 1 stop bit, no parity, no break control and no divisor latch */
+	CT_UART.LCTR = 3;
+
+	/* Enable loopback for test */
+	/*
+	 * NOTE!
+	 * loopback will prevent the UART from sending data to the output
+	 * pins. Remember to disable loopback in the MCR register before
+	 * looking for signals on your UART pins.
+	 */
+	CT_UART.MCTR = 0x10;
+
+	/* Choose desired response to emulation suspend events by configuring
+	 * FREE bit and enable UART by setting UTRST and URRST in PWR */
+	/* Allow UART to run free, enable UART TX/RX */
+	CT_UART.PWR = 0x6001;
+
+	/*** END INITIALIZATION ***/
+
+	/* Priming the 'hostbuffer' with a message */
+	hostBuffer.data[0] = 'H';
+	hostBuffer.data[1] = 'e';
+	hostBuffer.data[2] = 'l';
+	hostBuffer.data[3] = 'l';
+	hostBuffer.data[4] = 'o';
+	hostBuffer.data[5] = '!';
+	hostBuffer.data[6] = '\0';
+
+	/*** SEND SOME DATA ***/
+
+	/* Let's send/receive some dummy data */
+	for (cnt = 0; cnt < MAX_CHARS; cnt++) {
+		/* Load character, ensure it is not string termination */
+		if ((tx = hostBuffer.data[cnt]) == '\0')
+			break;
+		/* Write to the THR data bitfield, as defined in the AM335x TRM */
+		CT_UART.THR_bit.DATA = tx;
+
+		/* Because we are doing loopback, wait until LSR.DR == 1
+		 * indicating there is data in the RX FIFO */
+		while ((CT_UART.LSR1_bit.DR == 0x0));
+
+		/* Read the value from RBR */
+		buffer[cnt] = CT_UART.RBR_bit.DATA;
+
+		/* Wait for TX FIFO to be empty */
+		while (!((CT_UART.IIR_bit.INTID) == 0x1));
+	}
+
+	/*** DONE SENDING DATA ***/
+
+	/* Disable UART before halting */
+	CT_UART.PWR = 0x0;
+
+	/* Halt PRU core */
+	__halt();
+}

--- a/academy/uart/uart_loopback/firmware/main.c
+++ b/academy/uart/uart_loopback/firmware/main.c
@@ -1,0 +1,133 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (C) 2024-2024 Texas Instruments Incorporated - http://www.ti.com/
+ */
+
+#include <stdint.h>
+#include <pru_uart.h>
+
+/* The FIFO size on the PRU UART is 16 bytes; however, we are (arbitrarily)
+ * only going to send 8 at a time */
+#define FIFO_SIZE	16
+#define MAX_CHARS	8
+
+/* This hostBuffer structure is temporary but stores a data buffer */
+struct {
+	uint8_t msg; // Not used today
+	uint8_t data[FIFO_SIZE];
+} hostBuffer;
+
+/* Making this buffer global will force the received data into memory */
+uint8_t buffer[MAX_CHARS];
+
+int main(void)
+{
+	uint8_t tx;
+	uint8_t cnt;
+
+	/* FIXME: If modifying this to send data through the pins then PinMuxing
+	 * needs to be taken care of prior to running this code.
+	 * This is usually done via a GEL file in CCS or by the Linux driver */
+
+	/*
+	 * NOTE!!! As of AM62x TRM Rev B:
+	 *
+	 * - Definitions of PRU UART register field descriptions are missing
+	 *
+	 *   - The PRU UART hardware in AM335x & AM62x is EXACTLY identical.
+	 *     Thus, we can reference the AM335x TRM instead
+	 *
+	 *   - Detailed register field descriptions can be found in the AM335x
+	 *     TRM, Section PRU > Registers > PRU_ICSS_UART Registers
+	 *
+	 * - PRU UART register bitfields are wrong, for the registers where
+	 *   multiple registers share the same base address (RBR, THR, IIR, FCR)
+	 *
+	 *   - Refer to AM335x TRM for correct bitfields
+	 */
+
+	/*** INITIALIZATION ***/
+
+	/* Set up UART to function at 115200 baud - DLL divisor is 104 at 16x oversample
+	 * 192MHz / 104 / 16 = ~115200 */
+	CT_UART.DIVLSB = 104;
+	CT_UART.DIVMSB = 0;
+	CT_UART.MODE = 0x0;
+
+	/* Enable Interrupts in UART module. This allows the main thread to poll for
+	 * Receive Data Available and Transmit Holding Register Empty */
+	CT_UART.INT_EN = 0x7;
+
+	/* If FIFOs are to be used, select desired trigger level and enable
+	 * FIFOs by writing to FCR. FIFOEN bit in FCR must be set first before
+	 * other bits are configured */
+	CT_UART.FCR_bit.FIFOEN = 1;
+
+	/* Enable FIFOs */
+	CT_UART.FCR_bit.DMAMODE1 = 1;
+	/* RXFIFTL = 0x0 = 1-byte RX FIFO trigger */
+	/* Alternative: 8-byte RX FIFO trigger */
+	// CT_UART.FCR_bit.RXFIFTL = 0x2;
+
+	/* flush the FIFOs */
+	CT_UART.FCR_bit.TXCLR = 1;
+	CT_UART.FCR_bit.RXCLR = 1;
+
+	/* Choose desired protocol settings by writing to LCR */
+	/* 8-bit word, 1 stop bit, no parity, no break control and no divisor latch */
+	CT_UART.LCTR = 3;
+
+	/* Enable loopback for test */
+	/*
+	 * NOTE!
+	 * loopback will prevent the UART from sending data to the output
+	 * pins. Remember to disable loopback in the MCR register before
+	 * looking for signals on your UART pins.
+	 */
+	CT_UART.MCTR = 0x10;
+
+	/* Choose desired response to emulation suspend events by configuring
+	 * FREE bit and enable UART by setting UTRST and URRST in PWR */
+	/* Allow UART to run free, enable UART TX/RX */
+	CT_UART.PWR = 0x6001;
+
+	/*** END INITIALIZATION ***/
+
+	/* Priming the 'hostbuffer' with a message */
+	hostBuffer.data[0] = 'H';
+	hostBuffer.data[1] = 'e';
+	hostBuffer.data[2] = 'l';
+	hostBuffer.data[3] = 'l';
+	hostBuffer.data[4] = 'o';
+	hostBuffer.data[5] = '!';
+	hostBuffer.data[6] = '\0';
+
+	/*** SEND SOME DATA ***/
+
+	/* Let's send/receive some dummy data */
+	for (cnt = 0; cnt < MAX_CHARS; cnt++) {
+		/* Load character, ensure it is not string termination */
+		if ((tx = hostBuffer.data[cnt]) == '\0')
+			break;
+		/* Write to the THR data bitfield, as defined in the AM335x TRM */
+		CT_UART.THR_bit.DATA = tx;
+
+		/* Because we are doing loopback, wait until LSR.DR == 1
+		 * indicating there is data in the RX FIFO */
+		while ((CT_UART.LSR1_bit.DR == 0x0));
+
+		/* Read the value from RBR */
+		buffer[cnt] = CT_UART.RBR_bit.DATA;
+
+		/* Wait for TX FIFO to be empty */
+		while (!((CT_UART.IIR_bit.INTID) == 0x1));
+	}
+
+	/*** DONE SENDING DATA ***/
+
+	/* Disable UART before halting */
+	CT_UART.PWR = 0x0;
+
+	/* Halt PRU core */
+	__halt();
+}

--- a/academy/uart/uart_loopback/makefile
+++ b/academy/uart/uart_loopback/makefile
@@ -1,0 +1,100 @@
+include ../../../imports.mak
+
+#######################
+# project information #
+#######################
+
+PROJECT_NAME := uart_loopback
+SUPPORTED_PROCESSORS := am62x
+# Does the PRU code have dependencies outside of the open-pru repo?
+PRU_DEPENDENCIES :=
+# Use NON_PRU_DEPENDENCIES to select which makefiles to call for non-PRU cores
+NON_PRU_DEPENDENCIES :=
+
+###################
+# Prebuild checks #
+###################
+BUILD_PROJECT := y
+DEVICE_NON_PRU :=
+
+# Only build project if $(DEVICE) is in $(SUPPORTED_PROCESSORS)
+ifeq (,$(findstring $(DEVICE),$(SUPPORTED_PROCESSORS)))
+BUILD_PROJECT := n
+MESSAGE := Project $(PROJECT_NAME) does not have a build option for $(DEVICE)
+endif
+
+# Only build project if PRU dependencies exist
+ifneq (,$(PRU_DEPENDENCIES))
+# MCU+ SDK dependency?
+ifeq (mcuplus,$(findstring mcuplus,$(PRU_DEPENDENCIES)))
+ifneq ($(BUILD_MCUPLUS),y)
+BUILD_PROJECT := n
+MESSAGE ?= Project $(PROJECT_NAME) depends on MCU+ SDK, but BUILD_MCUPLUS != y.
+endif
+endif
+# Additional PRU dependency checks go here. For example:
+#ifeq (dependency,$(findstring dependency,$(PRU_DEPENDENCIES)))
+#if (dependency check fails)
+#BUILD_PROJECT := n
+#MESSAGE ?= Project $(PROJECT_NAME) depends on dependency, but dependency does not exist.
+#endif
+#endif
+endif
+
+# Only build non-PRU code if the non-PRU code is enabled in imports.mak
+ifeq ($(BUILD_MCUPLUS),y)
+ifeq (mcuplus,$(findstring mcuplus,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_mcuplus
+endif
+endif
+ifeq ($(BUILD_LINUX),y)
+ifeq (linux,$(findstring linux,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_linux
+endif
+endif
+
+###########################
+# Make and clean commands #
+###########################
+
+ifeq ($(BUILD_PROJECT),y)
+# "make" or "make all" builds projects that match $(DEVICE) set in imports.mak
+# "make" builds PRU firmware first, then host (non-PRU) code
+all: MESSAGE = "Building $(PROJECT_NAME) for $(DEVICE)"
+all: pre_build_message
+	$(MAKE) pru
+	$(MAKE) host
+
+# "make pru" builds only PRU firmware for $(DEVICE)
+pru: ARGUMENTS_PRU = all
+pru: $(DEVICE)
+
+# "make host" builds only host (non-PRU) code for $(DEVICE)
+host: ARGUMENTS_MCUPLUS = all
+host: $(DEVICE_NON_PRU)
+
+# "make clean" cleans projects that match $(DEVICE) set in imports.mak
+clean: ARGUMENTS_PRU = clean
+clean: ARGUMENTS_MCUPLUS = scrub
+clean: MESSAGE = "Cleaning $(PROJECT_NAME) for $(DEVICE)"
+clean: pre_build_message $(DEVICE) $(DEVICE_NON_PRU)
+
+else
+# if a prebuild check failed, print message and exit
+all clean pru host: pre_build_message
+endif
+
+pre_build_message:
+	@echo $(MESSAGE)
+
+######################
+# Target definitions #
+######################
+
+# provide target definitions for each supported processor
+# PRU firmware should be built before any RTOS code that includes it
+am62x:
+# am62x-sk
+	$(MAKE) -C firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+.PHONY: all clean pru host pre_build_message $(DEVICE) $(DEVICE_NON_PRU) $(SUPPORTED_PROCESSORS)

--- a/examples/LCD_interface/readme.md
+++ b/examples/LCD_interface/readme.md
@@ -1,5 +1,22 @@
 # LCD Interface
-This project uses PRU direct GPOs to output data from frame buffer memory to parallel RGB24 interface. The LCD display is 800x480 pixel with 24 bit color and 60 Hz frame rate. PRU resources used are limited to 200 MHz clock and functions available across ICSS_M (AM261/AM263) and ICSS_G (AM243/AM64) devices. The demo is built with AM243x LP because of availability of PRU pins on header. Display used is Newhaven NHD-4.3-800480CF-ASXP-CTP (https://newhavendisplay.com/content/specs/NHD-4.3-800480CF-ASXP-CTP.pdf). For back-light power supply we use TPS61169EVM (https://www.ti.com/lit/snvu455).   
+
+## Introduction
+
+This project uses PRU direct GPOs to output data from frame buffer memory to parallel RGB24 interface. The LCD display is 800x480 pixel with 24 bit color and 60 Hz frame rate. PRU resources used are limited to 200 MHz clock and functions available across ICSS_M (AM261/AM263) and ICSS_G (AM243/AM64) devices. The demo is built with AM243x LP because of availability of PRU pins on header. Display used is Newhaven NHD-4.3-800480CF-ASXP-CTP (https://newhavendisplay.com/content/specs/NHD-4.3-800480CF-ASXP-CTP.pdf). For back-light power supply we use TPS61169EVM (https://www.ti.com/lit/snvu455).
+
+## Supported Combinations
+
+Refer to open-pru/examples/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am243x    | LP-AM243 | MCU PLUS SDK TODO, OpenPRU TODO         |
 
 ## Overview
 RGB interface has wide data bus of 24 bit using 8 bits per color. In addition there are vertical and horizontal sync signals to define start and end of lines and frames. The display selected has additional DE (data enable) which is active for one line of data. Each 24 bit data is captured with DCLK (pixel clock) falling edge and there is a setup and hold time of 8 ns in this case. 
@@ -35,17 +52,28 @@ In the PRU firmware there are two macros which handle both alignment issues. The
 
 ## How to Run
 
-The project is split into three parts which are needed to run the demo. Clocking, pin-mux configuration and interrupts are specified graphically using sysconfig tool and example.syscfg file located in folder "C:\ti\GitHub\open-pru\examples\LCD_interface\am243x-lp\r5fss0-0_freertos". ARM project is used to run configuration of the demo including board and SoC configurations in sysconfig file. ARM also has PRU driver to load and run firmware. It is important that PRU1 starts before PRU0 to have core synchronization working. 
+The project is split into three parts which are needed to run the demo.
 
-Third component is assembly firmware for PRU0 and PRU1 which does the RGB output from frame buffer memory. 
+1. Clocking, pin-mux configuration and interrupts are specified graphically using
+sysconfig tool and example.syscfg file located in folder
+"\path\to\open-pru\examples\LCD_interface\am243x-lp\r5fss0-0_freertos".
 
-Here are the steps to run the demo. 
+2. The
+MCU+ SDK project is used to run configuration of the demo, including board and
+SoC configurations in sysconfig file. The MCU+ core uses the PRUICSS driver to
+load and run firmware. It is important that PRU1 starts before PRU0 to have core
+synchronization working.
 
-1. Clone project from Open-PRU github repository. 
-2. Import project in CCS at LCD_interface folder. CCS will import 3 projects, one for the ARM core and two for PRU0 and PRU1 core. 
+3. The third component is assembly firmware for PRU0 and PRU1 which does the RGB
+output from frame buffer memory.
+
+Here are the steps to run the demo.
+
+1. Clone project from Open-PRU github repository.
+2. Import project in CCS at LCD_interface folder. CCS will import 3 projects, one for the ARM core and two for PRU0 and PRU1 core.
 3. Build PRU0 and PRU1 firmware first which generates header files.
-4. Build ARM project which uses newly generated header files for PRU0 and PRU1 firmware. 
-5. Load and run ARM project. It will also load and run PRU1 first followed by PRU0 code. 
+4. Build ARM project which uses newly generated header files for PRU0 and PRU1 firmware.
+5. Load and run ARM project. It will also load and run PRU1 first followed by PRU0 code.
 
 It makes sense to validate output signals with a logic scope. Important signals to capture are DCLK, VSYNC, HSYNC, DE and first bit of data line for each color. The documentation folder has PPT which contains timing plots for verification. After validating correct signal output the display can be connected to the launchpad header. The PPT shows the pin-mapping from Launchpad header perspective. 
 

--- a/examples/LCD_interface/readme.md
+++ b/examples/LCD_interface/readme.md
@@ -16,7 +16,7 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am243x    | LP-AM243 | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am243x    | LP-AM243 | MCU PLUS SDK FIXME, OpenPRU FIXME         |
 
 ## Overview
 RGB interface has wide data bus of 24 bit using 8 bits per color. In addition there are vertical and horizontal sync signals to define start and end of lines and frames. The display selected has additional DE (data enable) which is active for one line of data. Each 24 bit data is captured with DCLK (pixel clock) falling edge and there is a setup and hold time of 8 ns in this case. 

--- a/examples/custom_frequency_generator/README.md
+++ b/examples/custom_frequency_generator/README.md
@@ -1,10 +1,26 @@
 # Custom Frequency Generator
 
+## Introduction
+
 The project generates a square wave of the desired average clock frequency from the available system clock. A fractional adder is used to generate a pulse with a configurable average frequency.
 
 <img src="pictures/freq_gen_setup.png" alt="CFG_setup" width="600">
 <figcaption>Fig.1 Frequency Generator setup</figcaption>
 </figure>
+
+## Supported Combinations
+
+Refer to open-pru/examples/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am243x    | LP-AM243 | MCU PLUS SDK 11.0, OpenPRU TODO         |
 
 ## Overview
 
@@ -69,8 +85,8 @@ For the previous example,
 
 1. Import the device specific project from 'examples/custom_frequency_generator' in the open-pru repository.
 2. Keep the default configuration (for 16.384Mhz) or change the configuration according to section [Configuration](#configuration) for a desired frequency.
-3.  Build and load the "*.out" file into the core 'ICSSG0 PRU0' of AM243x device. 
-4. Run the core and the desired average frequency is available on PIN PRU0_GPO0(BP.33). To view the signal, connect a channel of a logic scope to the PIN. 
+3.  Build and load the "*.out" file into the core 'ICSSG0 PRU0' of AM243x device.
+4. Run the core and the desired average frequency is available on PIN PRU0_GPO0(BP.33). To view the signal, connect a channel of a logic scope to the PIN.
 
 ## Results
 

--- a/examples/custom_frequency_generator/README.md
+++ b/examples/custom_frequency_generator/README.md
@@ -20,7 +20,7 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am243x    | LP-AM243 | MCU PLUS SDK 11.0, OpenPRU TODO         |
+| am243x    | LP-AM243 | MCU PLUS SDK 11.0, OpenPRU FIXME         |
 
 ## Overview
 

--- a/examples/empty/readme.md
+++ b/examples/empty/readme.md
@@ -2,40 +2,35 @@
 
 ## Introduction
 
-This example acts as a getting started point for PRU firmware development in assembly.
+This example acts as a getting started point for PRU firmware development in
+assembly.
 
-# Supported Combinations
+## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSG          | ICSSG0 - PRU0, PRU1, RTU0, RTU1, TX_PRU0,TX_PRU1
- ICSSM          | ICSSM0 - PRU0, PRU1
-                | ICSSM1 - PRU0, PRU1 (am261x only)
- Toolchain      | pru-cgt
- Board          | am64x-evm, am243x-evm, am243x-lp, am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp, am62x-sk
- Example folder | examples/empty/
+Refer to open-pru/examples/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
 
-# Steps to Run the Example
+## Validated HW & SW
 
-> Prerequisite: [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt) should be installed at: `C:/ti/`
+This project was tested on hardware with these software versions:
 
-- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU, After this `main.asm`, `linker.cmd` files gets copied to ccs workspace of PRU project. The `main.asm` contains sample code to halt PRU program
+| Processor | Hardware   | Software                   |
+| --------- | ---------- | -------------------------- |
+| AM243x    | TODO       | TODO                       |
+| AM261x    | TODO       | TODO                       |
+| AM263Px   | TODO       | TODO                       |
+| AM263x    | TODO       | TODO                       |
+| AM62x     | TODO       | TODO                       |
+| AM64x     | TODO       | TODO                       |
 
-     - Build the PRU project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Build Flow: Once you click on build in PRU project, firmware header file which is generated in release or debug folder of ccs workspace, is moved to  `<open-pru/examples/empty/firmware/device/>`
+## Overview
 
-     - Build the R5F project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Firmware header file path is included in R5F project include options by default, Instructions in Firmware header file can be written into PRU IRAM memory using PRUICSS_loadFirmware API (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe))
-          - Build Flow: Once you click on build in R5F project, SysConfig files are generated, Finally the R5F project will be generated using both the generated SysConfig and PRU project binaries.
+For more information about using this example to write your own PRU firmware,
+refer to
+[Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).
 
-     - Launch a CCS debug session and run the executable, (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_LAUNCH_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_LAUNCH_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_LAUNCH_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_LAUNCH_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_LAUNCH_PAGE.html))
+## Steps to Run the Example
 
-- **When using makefiles to build**:
-     - For steps on how to use makefiles, run `make help` from the root folder
-       of the open-pru repository.
-
-# Writing PRU code
-
-* You can modify this example to write your own firmware. For more information,
-  refer to
-  [Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).
+Refer to the **PRU Academy > PRU Getting Started Labs** for steps to build,
+load, and debug PRU firmware.

--- a/examples/empty/readme.md
+++ b/examples/empty/readme.md
@@ -17,12 +17,12 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware   | Software                   |
 | --------- | ---------- | -------------------------- |
-| AM243x    | TODO       | TODO                       |
-| AM261x    | TODO       | TODO                       |
-| AM263Px   | TODO       | TODO                       |
-| AM263x    | TODO       | TODO                       |
-| AM62x     | TODO       | TODO                       |
-| AM64x     | TODO       | TODO                       |
+| AM243x    | FIXME       | FIXME                       |
+| AM261x    | FIXME       | FIXME                       |
+| AM263Px   | FIXME       | FIXME                       |
+| AM263x    | FIXME       | FIXME                       |
+| AM62x     | FIXME       | FIXME                       |
+| AM64x     | FIXME       | FIXME                       |
 
 ## Overview
 

--- a/examples/empty_c/readme.md
+++ b/examples/empty_c/readme.md
@@ -5,38 +5,32 @@
 This example acts as a getting started point for PRU firmware development in
 C, or mixed C and assembly.
 
-# Supported Combinations
+## Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSG          | ICSSG0 - PRU0, PRU1, RTU0, RTU1, TX_PRU0,TX_PRU1
- ICSSM          | ICSSM0 - PRU0, PRU1
-                | ICSSM1 - PRU0, PRU1 (am261x only)
- Toolchain      | pru-cgt
- Board          | am64x-evm, am243x-evm, am243x-lp, am261x-lp, am261x-som, am263px-cc, am263px-lp, am263x-cc, am263x-lp, am62x-sk
- Example folder | examples/empty_c/
+Refer to open-pru/examples/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
 
-# Steps to Run the Example
+## Validated HW & SW
 
-> Prerequisite: [PRU-CGT-2-3](https://www.ti.com/tool/PRU-CGT) (ti-pru-cgt) should be installed at: `C:/ti/`
+This project was tested on hardware with these software versions:
 
-- **When using CCS projects to build**, import the CCS project from the above mentioned Example folder path for R5F and PRU, After this `main.asm`, `linker.cmd` files gets copied to ccs workspace of PRU project. The `main.asm` contains sample code to halt PRU program
+| Processor | Hardware   | Software                   |
+| --------- | ---------- | -------------------------- |
+| AM243x    | TODO       | TODO                       |
+| AM261x    | TODO       | TODO                       |
+| AM263Px   | TODO       | TODO                       |
+| AM263x    | TODO       | TODO                       |
+| AM62x     | TODO       | TODO                       |
+| AM64x     | TODO       | TODO                       |
 
-     - Build the PRU project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Build Flow: Once you click on build in PRU project, firmware header file which is generated in release or debug folder of ccs workspace, is moved to  `<open-pru/examples/empty/firmware/device/>`
+## Overview
 
-     - Build the R5F project using the CCS project menu (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_PROJECTS_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_PROJECTS_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_PROJECTS_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)).
-          - Firmware header file path is included in R5F project include options by default, Instructions in Firmware header file can be written into PRU IRAM memory using PRUICSS_loadFirmware API (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/group__DRV__PRUICSS__MODULE.html#ga3e7c763e5343fe98f7011f388a0b7ffe))
-          - Build Flow: Once you click on build in R5F project, SysConfig files are generated, Finally the R5F project will be generated using both the generated SysConfig and PRU project binaries.
+For more information about using this example to write your own PRU firmware,
+refer to
+[Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).
 
-     - Launch a CCS debug session and run the executable, (see [for AM64x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/latest/exports/docs/api_guide_am64x/CCS_LAUNCH_PAGE.html), [for AM243x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM243X/latest/exports/docs/api_guide_am243x/CCS_LAUNCH_PAGE.html), [for AM261x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM261X/latest/exports/docs/api_guide_am261x/CCS_LAUNCH_PAGE.html), [for AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_LAUNCH_PAGE.html), [for AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_LAUNCH_PAGE.html))
+## Steps to Run the Example
 
-- **When using makefiles to build**:
-     - For steps on how to use makefiles, run `make help` from the root folder
-       of the open-pru repository.
-
-# Writing PRU code
-
-* You can modify this example to write your own firmware. For more information,
-  refer to
-  [Creating a New Project in the OpenPRU Repo](../../docs/open_pru_create_new_project.md).
+Refer to the **PRU Academy > PRU Getting Started Labs** for steps to build,
+load, and debug PRU firmware.

--- a/examples/empty_c/readme.md
+++ b/examples/empty_c/readme.md
@@ -17,12 +17,12 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware   | Software                   |
 | --------- | ---------- | -------------------------- |
-| AM243x    | TODO       | TODO                       |
-| AM261x    | TODO       | TODO                       |
-| AM263Px   | TODO       | TODO                       |
-| AM263x    | TODO       | TODO                       |
-| AM62x     | TODO       | TODO                       |
-| AM64x     | TODO       | TODO                       |
+| AM243x    | FIXME       | FIXME                       |
+| AM261x    | FIXME       | FIXME                       |
+| AM263Px   | FIXME       | FIXME                       |
+| AM263x    | FIXME       | FIXME                       |
+| AM62x     | FIXME       | FIXME                       |
+| AM64x     | FIXME       | FIXME                       |
 
 ## Overview
 

--- a/examples/fft/README.md
+++ b/examples/fft/README.md
@@ -8,6 +8,21 @@
 ## Introduction
 The code performs a real valued 4096-point Fast-Fourier Transform on 4096 discrete input samples in the ICSS Shared Memory. The implementation makes use of a Real-valued DIT Split-Radix algorithm and has two versions that each runs on ICSSG PRU0 and ICSSM PRU0.  
 
+## Supported Combinations
+
+Refer to open-pru/examples/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware | Software                                        |
+| --------- | -------- | ----------------------------------------------- |
+| am243x    | TODO     | MCU PLUS SDK 10.01.00.32, OpenPRU TODO          |
+| am261x    | TODO     | MCU PLUS SDK 10.00.01.10, OpenPRU TODO          |
+
 ## Overview
 The algorithm assumes input samples in Q24 format to be present in the configured memory space. The current implementation assumes unsigned inputs which are common for ADC measurement values. 
 

--- a/examples/fft/README.md
+++ b/examples/fft/README.md
@@ -20,8 +20,8 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                        |
 | --------- | -------- | ----------------------------------------------- |
-| am243x    | TODO     | MCU PLUS SDK 10.01.00.32, OpenPRU TODO          |
-| am261x    | TODO     | MCU PLUS SDK 10.00.01.10, OpenPRU TODO          |
+| am243x    | FIXME     | MCU PLUS SDK 10.01.00.32, OpenPRU FIXME          |
+| am261x    | FIXME     | MCU PLUS SDK 10.00.01.10, OpenPRU FIXME          |
 
 ## Overview
 The algorithm assumes input samples in Q24 format to be present in the configured memory space. The current implementation assumes unsigned inputs which are common for ADC measurement values. 

--- a/examples/logic_scope/README.md
+++ b/examples/logic_scope/README.md
@@ -1,7 +1,23 @@
 # 8-channel Logic Scope
 
+## Introduction
+
 The project realizes a simple logic scope that uses two cores, PRU0 and RTU0, to continuously sample a configured GPI Pin. The sampling frequency is restricted only by the clock frequency of PRU and for AM243 we could configure the clock upto 333Mhz. This gives us a maximum sampling rate of 333Mhz. The number of samples that need to be captured can be configured in multiples of 100 and the maximum number of samples is only restricted by the size of the configured storage memory. For MSRAM, this is around 2MB of sample size. The Logic-scope reads 1 Byte of data every clock cycle which contains logic data from 8 input channels.  The trigger for sampling in current implementation is set to a low to high in the 8th channel (PRU0.GPI7).
 ![alt text](images/dcls_overview.png)
+
+## Supported Combinations
+
+Refer to open-pru/examples/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am243x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
 
 ## Overview
 

--- a/examples/logic_scope/README.md
+++ b/examples/logic_scope/README.md
@@ -17,7 +17,7 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am243x    | TODO     | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am243x    | FIXME     | MCU PLUS SDK FIXME, OpenPRU FIXME         |
 
 ## Overview
 

--- a/examples/pru_emif/readme.md
+++ b/examples/pru_emif/readme.md
@@ -11,6 +11,19 @@ The F283879D initiates requests for 16-bit or 32-bit reads/writes over EMIF1 & P
 ICSSG PRU cores has been implemented to emulate the EMIF interface to repsond to 16 bit reads/writes. 
 It also responds to 32 bit reads/writes by converting into two 16 bit read/writes request seperately. 
 
+## Supported Combinations
+
+Refer to open-pru/examples/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware     | Software                                                                         |
+| --------- | ------------ | -------------------------------------------------------------------------------- |
+| am243x    | TMDS243GPEVM | MCU PLUS SDK TODO, C2000Ware 4.02.00.00, C2000 CGT 22.6.1 LTS, OpenPRU TODO      |
 
 ## Setup Details
 

--- a/examples/pru_emif/readme.md
+++ b/examples/pru_emif/readme.md
@@ -23,7 +23,7 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware     | Software                                                                         |
 | --------- | ------------ | -------------------------------------------------------------------------------- |
-| am243x    | TMDS243GPEVM | MCU PLUS SDK TODO, C2000Ware 4.02.00.00, C2000 CGT 22.6.1 LTS, OpenPRU TODO      |
+| am243x    | TMDS243GPEVM | MCU PLUS SDK FIXME, C2000Ware 4.02.00.00, C2000 CGT 22.6.1 LTS, OpenPRU FIXME      |
 
 ## Setup Details
 

--- a/examples/pru_emif/readme.md
+++ b/examples/pru_emif/readme.md
@@ -11,6 +11,19 @@ The F283879D initiates requests for 16-bit or 32-bit reads/writes over EMIF1 & P
 ICSSG PRU cores has been implemented to emulate the EMIF interface to respond to 16 bit reads/writes.
 It also responds to 32 bit reads/writes by converting into two 16 bit read/writes request separately.
 
+## Supported Combinations
+
+Refer to open-pru/examples/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware     | Software                                                                         |
+| --------- | ------------ | -------------------------------------------------------------------------------- |
+| am243x    | TMDS243GPEVM | MCU PLUS SDK TODO, C2000Ware 4.02.00.00, C2000 CGT 22.6.1 LTS, OpenPRU TODO      |
 
 ## Setup Details
 

--- a/examples/rpmsg_echo_linux/makefile
+++ b/examples/rpmsg_echo_linux/makefile
@@ -93,7 +93,6 @@ pre_build_message:
 
 # provide target definitions for each supported processor
 # PRU firmware should be built before any RTOS code that includes it
-# TODO: what do we want to call the PRU Subsystem folder for AM62x? pruss, pruss0, icssm0, something else?
 am62x:
 # am62x-sk
 	$(MAKE) -C firmware/am62x-sk/pruss0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)

--- a/examples/spi_loopback/readme.md
+++ b/examples/spi_loopback/readme.md
@@ -5,21 +5,21 @@
 This example provides a base for running loopback spi connection between a pair of master and slave PRU cores. 
 The example uses generic SPI macros introduced in files spi_master_macros.inc and spi_slave_macros.inc to emulate generic SPI master and slave interfaces over PRU GPIO pins.
 
- ## Overview
- ### Timing Parameters
- All cycle level frequency calculations are based on a 333MHz PRU System clock, which gives 3ns per instruction cycle, i.e $t_{f} = 3ns$
- 
- $t_{slew}$ : Slew rate of Data toggling (slew rate of PRU GPIO mode pin) = $2ns$
- $t_{p}$ : Propagation delay of wire (In the example, a 15 cm wire was used) = $0.5ns$
- #### SPI Master Macros: 
+## Overview
+### Timing Parameters
+All cycle level frequency calculations are based on a 333MHz PRU System clock, which gives 3ns per instruction cycle, i.e $t_{f} = 3ns$
 
- | Macros Name | Description         | Peak cycles per bit | Theoretical Max. SCLK | Recommended delay components (50% duty cycle) | Practical Max. SCLK
- |--------------|:------------------:|:--------:|:--------:|:-------:|:-------:|
- | m_read_packet_spi_msb_gpo_sclk |  SPI Master side macro to read 1 data packet through SPI interface MSB first.  | (2+d1)+(5+d2) cycles  | 33.33MHz | d1 =10, d2 =7 | 13.88MHz
- | m_read_packet_spi_lsb_gpo_sclk |  SPI Master side macro to read 1 data packet through SPI interface LSB first.  | (2+d1)+(5+d2) cycles  | 33.33MHz | d1 =10, d2 =7 | 13.88MHz
- | m_send_packet_spi_msb_gpo_sclk |  SPI Master side macro to send 1 data packet through SPI interface MSB first.  | (4+d1)+(3+d2) cycles  | 41.66MHz | d1 =0, d2 =1 | 41.66MHz
- | m_send_packet_spi_lsb_gpo_sclk |  SPI Master side macro to send 1 data packet through SPI interface LSB first.  | (4+d1)+(3+d2) cycles  | 41.66MHz | d1 =0, d2 =1 | 41.66MHz
- | m_transfer_packet_spi_master_gpo_sclk |  SPI Master side macro to read 1 data packet and write 1 data packet concurrently through the SPI interface. | (4+d1)+(6+d2) cycles  | 27.77MHz | d1 =9, d2 =7 | 12.8MHz
+$t_{slew}$ : Slew rate of Data toggling (slew rate of PRU GPIO mode pin) = $2ns$
+$t_{p}$ : Propagation delay of wire (In the example, a 15 cm wire was used) = $0.5ns$
+#### SPI Master Macros: 
+
+| Macros Name | Description         | Peak cycles per bit | Theoretical Max. SCLK | Recommended delay components (50% duty cycle) | Practical Max. SCLK
+|--------------|:------------------:|:--------:|:--------:|:-------:|:-------:|
+| m_read_packet_spi_msb_gpo_sclk |  SPI Master side macro to read 1 data packet through SPI interface MSB first.  | (2+d1)+(5+d2) cycles  | 33.33MHz | d1 =10, d2 =7 | 13.88MHz
+| m_read_packet_spi_lsb_gpo_sclk |  SPI Master side macro to read 1 data packet through SPI interface LSB first.  | (2+d1)+(5+d2) cycles  | 33.33MHz | d1 =10, d2 =7 | 13.88MHz
+| m_send_packet_spi_msb_gpo_sclk |  SPI Master side macro to send 1 data packet through SPI interface MSB first.  | (4+d1)+(3+d2) cycles  | 41.66MHz | d1 =0, d2 =1 | 41.66MHz
+| m_send_packet_spi_lsb_gpo_sclk |  SPI Master side macro to send 1 data packet through SPI interface LSB first.  | (4+d1)+(3+d2) cycles  | 41.66MHz | d1 =0, d2 =1 | 41.66MHz
+| m_transfer_packet_spi_master_gpo_sclk |  SPI Master side macro to read 1 data packet and write 1 data packet concurrently through the SPI interface. | (4+d1)+(6+d2) cycles  | 27.77MHz | d1 =9, d2 =7 | 12.8MHz
 
 Timing parameters for macros: **m_read_packet_spi_msb_gpo_sclk** and **m_read_packet_spi_lsb_gpo_sclk** are shown below:
 
@@ -78,8 +78,8 @@ Timing parameters for macro **m_transfer_packet_spi_master_gpo_sclk** is shown b
  |$t_{si}$         | SetUp time: Time SDI needs to be stable before sampling edge | $0$ |  | ns |
  |$t_{hi}$         | Hold time: Time SDI needs to be stable after sampling edge | $t_{f}$ |  | ns |
 
- #### SPI Slave Macros:  
-  | Macros Name | Description         | Peak cycle per bit| Max. SCLK | Practical Max. SCLK| 
+#### SPI Slave Macros:  
+ | Macros Name | Description         | Peak cycle per bit| Max. SCLK | Practical Max. SCLK| 
  |--------------|:------------------:|:--------:|:--------:|:--------:|
  | m_read_packet_spi_slave_msb_gpi_sclk |  SPI Slave side macro to read 1 data packet through SPI interface MSB first.  | 7 cycles  | 47.619MHz |47.619MHz |
  | m_read_packet_spi_slave_lsb_gpi_sclk |  SPI Slave side macro to read 1 data packet through SPI interface LSB first.  | 7 cycles  | 47.619MHz | 47.619MHz |
@@ -215,11 +215,17 @@ Note: None of the ICSS Broadside Accelerators are used for this implementation.
 
  ## Limitations
  Some of the macros were not stable at the theoretical maximum. These include: m_send_packet_spi_slave_msb_gpo_sclk, m_send_packet_spi_slave_lsb_gpo_sclk, m_transfer_packet_spi_slave_gpi_sclk, m_read_packet_spi_msb_gpo_sclk, m_read_packet_spi_lsb_gpo_sclk and m_transfer_packet_spi_master_gpo_sclk. Experimentally a frequency limitation was found and is documented in this document a "Practical Max SCLK." at which tests where successfully carried out.
-# Supported Combinations
 
- Parameter      | Value
- ---------------|-----------
- ICSSG          | ICSSG0 - PRU0, PRU1
- Toolchain      | pru-cgt
- Board          | am243x-lp
- Example folder | examples/spi_loopback
+## Supported Combinations
+
+Refer to open-pru/examples/readme.md > Supported processors per-project
+for the list of processors that support building this project, and information
+about porting this project to other processors.
+
+## Validated HW & SW
+
+This project was tested on hardware with these software versions:
+
+| Processor | Hardware | Software                                |
+| --------- | -------- | --------------------------------------- |
+| am243x    | LP-AM243 | MCU PLUS SDK TODO, OpenPRU TODO         |

--- a/examples/spi_loopback/readme.md
+++ b/examples/spi_loopback/readme.md
@@ -228,4 +228,4 @@ This project was tested on hardware with these software versions:
 
 | Processor | Hardware | Software                                |
 | --------- | -------- | --------------------------------------- |
-| am243x    | LP-AM243 | MCU PLUS SDK TODO, OpenPRU TODO         |
+| am243x    | LP-AM243 | MCU PLUS SDK FIXME, OpenPRU FIXME         |

--- a/examples/spi_loopback/spi_loopback_app/am243x-lp/spi_pru_demo.c
+++ b/examples/spi_loopback/spi_loopback_app/am243x-lp/spi_pru_demo.c
@@ -78,7 +78,7 @@ void SPI_pru_demo_main(void *args)
 
      while (1)
      {
-        /*TODO: [PINDSW-8471] Add unit test cases here for CI CD automation */
+        /*FIXME: [PINDSW-8471] Add unit test cases here for CI CD automation */
         ClockP_usleep(1);
      }
 


### PR DESCRIPTION
Update all README files in the OpenPRU repository to align with the latest OpenPRU v2026.01.00.

Port the HW UART project from the PRU Software Support Package (PSSP) as well as the C code version of the MAC example.

The project ports were used to test the behavior of AI agents based on https://github.com/TexasInstruments/open-pru/pull/130.

This pull request should be merged in before https://github.com/TexasInstruments/open-pru/pull/128

Ported code has not been tested on silicon yet

The README updates are the first step to addressing https://github.com/TexasInstruments/open-pru/issues/42