### PR TITLE
docs: add portable assembly include path guidance

### DIFF
--- a/best_practices.md
+++ b/best_practices.md
@@ -727,6 +727,13 @@ Compiler does not support forward declarations of symbols via the .set directive
 
 ## Header File include rules
 - It is recommended to include only header files required in .asm sources
+- Use the backslash character (`\`) in PRU assembly `.include` paths for
+  cross-platform compatibility with the PRU assembler. Do not use forward
+  slash (`/`) separators in `.include` operands.
+  ```
+  ; portable across Windows and Linux builds for PRU assembly includes
+  .include "source\firmware\common\icss_constant_defines.inc"
+  ```
 - Four underscores recommended in header guard, example below:
   ```
   .if !$isdefed("____icss_header_h")
@@ -954,6 +961,3 @@ For the complete and up-to-date PRU Assembly Instruction Cheat Sheet, see:
 - **Solution**: Document all timing-critical sections and hardware dependencies
 
 ---
-
-
-

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -212,6 +212,16 @@ pr_compliances:
     failure_criteria: |
       - "Any .asm, .inc, .c, or .h file containing tab characters"
 
+  - title: "Portable Assembly Include Paths"
+    compliance_label: true
+    objective: "Ensure assembly .include paths use PRU assembler-compatible separators (best_practices.md §Header File include rules)"
+    success_criteria: |
+      - 'All new or modified .asm and .inc files use the backslash character (`\`) in .include paths'
+      - "Relative include paths remain valid when built on Windows or Linux hosts"
+    failure_criteria: |
+      - "New or modified .include paths use the forward slash character (`/`)"
+      - "Include paths rely on non-PRU-assembler slash path separators"
+
   - title: "Bugfix: Shared Library Impact"
     compliance_label: true
     objective: "Ensure that bugfixes to shared libraries in source/ do not silently break other projects (docs/contributing.md §'Adding a bugfix')"


### PR DESCRIPTION
## Summary
- document portable `.include` path separators for PRU assembly sources
- add a matching compliance rule so new/modified assembly includes can be reviewed consistently

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("pr_compliance_checklist.yaml"); puts "YAML OK"'`
- `rg -n '^\s*\.include\s+"[^"]*\\\\' --glob '*.{asm,inc}' . || true`

Closes #51.
