### PR TITLE
Update OPEN_PRU product version to 2026.01.00

### DIFF
--- a/.metadata/product.json
+++ b/.metadata/product.json
@@ -1,7 +1,7 @@
 {
     "name": "OPEN_PRU",
     "displayName": "OPEN_PRU",
-    "version": "07.03.01",
+    "version": "2026.01.00",
     "documentationPath": "../docs",
     "includePaths": [
         "../source",

--- a/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/assembly_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_and_inline_assembly/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/getting_started_labs/c_code/solution/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/academy/gpio/gpio_toggle/am261x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/gpio/gpio_toggle/am261x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM261x_ZFG" --part "AM2612" --package "ZFG" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM2612" --package "NFBGA (ZFG)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM261x_ZFG" --part "AM2612" --package "ZFG" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM2612" --package "NFBGA (ZFG)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/academy/gpio/gpio_toggle/am263px-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/gpio/gpio_toggle/am263px-lp/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_C" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-C)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_C" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-C)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/academy/gpio/gpio_toggle/am263x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/gpio/gpio_toggle/am263x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/academy/intc/intc_mcu/am261x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/intc/intc_mcu/am261x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM261x_ZFG" --part "AM2612" --package "ZFG" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM2612" --package "NFBGA (ZFG)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM261x_ZFG" --part "AM2612" --package "ZFG" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM2612" --package "NFBGA (ZFG)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/academy/intc/intc_mcu/am263px-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/intc/intc_mcu/am263px-cc/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_S" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-S)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_S" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-S)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/academy/intc/intc_mcu/am263px-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/intc/intc_mcu/am263px-lp/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_C" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-C)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263Px" --part "AM263P4" --package "ZCZ_C" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM263P4-Q1" --package "NFBGA (ZCZ-C)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/academy/intc/intc_mcu/am263x-cc/r5fss0-0_freertos/example.syscfg
+++ b/academy/intc/intc_mcu/am263x-cc/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/academy/intc/intc_mcu/am263x-lp/r5fss0-0_freertos/example.syscfg
+++ b/academy/intc/intc_mcu/am263x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM2631-Q1" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM2631-Q1" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/docs/tagging_checklist.md
+++ b/docs/tagging_checklist.md
@@ -85,9 +85,10 @@ SDK versions that were validated during [Test SDK releases](#test-sdk-releases):
 ## Update the .metadata version
 
 Update the OpenPRU version field to the new release tag (e.g. `2026.01.00`) in
-this file:
+these files:
 
-`.metadata/.tirex/package.tirex.json`
+* `.metadata/.tirex/package.tirex.json`
+* `.metadata/product.json`
 
 ## Update the year
 

--- a/examples/LCD_interface/mcuplus/am243x-lp/r5fss0-0_freertos/example.syscfg
+++ b/examples/LCD_interface/mcuplus/am243x-lp/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM243x_ALX_beta" --part "ALX" --package "ALX" --context "r5fss0-0" --product "OPEN_PRU@07.03.01" --product "MCU_PLUS_SDK_AM243x@10.00.00"
- * @v2CliArgs --device "AM2434" --package "FCCSP (ALX)" --context "r5fss0-0" --product "OPEN_PRU@07.03.01" --product "MCU_PLUS_SDK_AM243x@10.00.00"
+ * @cliArgs --device "AM243x_ALX_beta" --part "ALX" --package "ALX" --context "r5fss0-0" --product "OPEN_PRU@2026.01.00" --product "MCU_PLUS_SDK_AM243x@10.00.00"
+ * @v2CliArgs --device "AM2434" --package "FCCSP (ALX)" --context "r5fss0-0" --product "OPEN_PRU@2026.01.00" --product "MCU_PLUS_SDK_AM243x@10.00.00"
  * @versions {"tool":"1.21.0+3721"}
  */
 

--- a/examples/empty/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
+++ b/examples/empty/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 

--- a/examples/empty_c/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
+++ b/examples/empty_c/mcuplus/am263x-cc/r5fss0-0_freertos/example.syscfg
@@ -1,8 +1,8 @@
 /**
  * These arguments were used when this file was generated. They will be automatically applied on subsequent loads
  * via the GUI or CLI. Run CLI with '--help' for additional information on how to override these arguments.
- * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
- * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@07.03.01"
+ * @cliArgs --device "AM263x_beta" --part "AM263x" --package "ZCZ" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
+ * @v2CliArgs --device "AM2634" --package "NFBGA (ZCZ)" --context "r5fss0-0" --product "MCU_PLUS_SDK@07.03.01" --product "OPEN_PRU@2026.01.00"
  * @versions {"tool":"1.23.0+4000"}
  */
 


### PR DESCRIPTION
Fixes #108

The OPEN_PRU product version was stale at `07.03.01`. This updates it to the `2026.01.00` release version in the two places the issue identifies:

1. `.metadata/product.json` — `version` field
2. SysConfig files for MCU+ cores — the `--product OPEN_PRU@<ver>` pin in `@cliArgs`/`@v2CliArgs`

Only the `OPEN_PRU@` product version is changed; `MCU_PLUS_SDK@07.03.01` is intentionally left untouched (separate product, out of scope for this issue).

16 files changed, version-string-only edits.

CI: all three workflows (Makefile CI, GNU Toolchain CI, CCS Build — full device matrix) pass on this change on my fork.