### PR TITLE
Fix #100: harden RPMsg buffer validation

### DIFF
--- a/examples/gcc_rpmsg_echo_linux/main.c
+++ b/examples/gcc_rpmsg_echo_linux/main.c
@@ -90,6 +90,7 @@ int main(void)
 				/* Clear the event status */
 				CT_INTC.STATUS_CLR_INDEX_REG_bit.STATUS_CLR_INDEX = FROM_ARM_HOST;
 				/* Receive all available messages. Multiple messages can be sent per kick */
+				len = sizeof(payload);
 				while (pru_rpmsg_receive(&transport, &src, &dst, payload, &len) == PRU_RPMSG_SUCCESS) {
 					/* On PRU_RPMSG_SUCCESS, the pointers will be valid.
 					 * On len=0, the assembly will never loop even once, so it is
@@ -120,6 +121,7 @@ int main(void)
 					      "r0.b0", "r0.b1");		/* clobbered registers (always 8-bit!) */
 					/* Echo the message back to the same address from which we just received */
 					pru_rpmsg_send(&transport, dst, src, payload, len);
+					len = sizeof(payload);
 				}
 			}
 		}

--- a/examples/rpmsg_echo_linux/firmware/main.c
+++ b/examples/rpmsg_echo_linux/firmware/main.c
@@ -107,9 +107,11 @@ void main(void)
 				/* Clear the event status */
 				CT_INTC.STATUS_CLR_INDEX_REG_bit.STATUS_CLR_INDEX = FROM_ARM_HOST;
 				/* Receive all available messages. Multiple messages can be sent per kick */
+				len = sizeof(payload);
 				while (pru_rpmsg_receive(&transport, &src, &dst, payload, &len) == PRU_RPMSG_SUCCESS) {
 					/* Echo the message back to the same address from which we just received */
 					pru_rpmsg_send(&transport, dst, src, payload, len);
+					len = sizeof(payload);
 				}
 			}
 		}

--- a/source/include/linux/pru_rpmsg.h
+++ b/source/include/linux/pru_rpmsg.h
@@ -162,8 +162,9 @@ int16_t pru_rpmsg_init(
 *			     for which channel the message is intended on the PRU)
 *			data: a pointer that is populated with a local data buffer
 *			      containing the message payload
-*			len: a pointer that is populated with the length of the
-*			     message payload
+*			len: a pointer containing the size of the local data
+*			     buffer. This is populated with the length of the
+*			     message payload on success.
 *
 * Description	:	pru_rpmsg_receive uses the pru_virtqueue interface to get
 *			an available buffer, copy the buffer into local memory,
@@ -176,7 +177,10 @@ int16_t pru_rpmsg_init(
 * Return Value	:	Returns PRU_RPMSG_NO_BUF_AVAILABLE if there is currently no
 *			buffer available for receive. Returns PRU_RPMSG_INVALID_HEAD
 *			if the head index returned for the available buffer is
-*			invalid. Returns PRU_RPMSG_SUCCESS if the message is
+*			invalid. Returns PRU_RPMSG_BUF_TOO_SMALL if the local
+*			data buffer is too small for the received payload or if
+*			the virtqueue descriptor is too small for the RPMsg
+*			header. Returns PRU_RPMSG_SUCCESS if the message is
 *			successfully received.
 */
 int16_t pru_rpmsg_receive(

--- a/source/rpmsg/pru_rpmsg.c
+++ b/source/rpmsg/pru_rpmsg.c
@@ -105,7 +105,14 @@ int16_t pru_rpmsg_send(
 	head = pru_virtqueue_get_avail_buf(virtqueue, (void **)&msg, &msg_len);
 
 	if (head < 0)
-		return PRU_RPMSG_NO_BUF_AVAILABLE;
+		return (head == PRU_VIRTQUEUE_INVALID_HEAD) ?
+			PRU_RPMSG_INVALID_HEAD : PRU_RPMSG_NO_BUF_AVAILABLE;
+
+	if (msg_len < (sizeof(struct pru_rpmsg_hdr) + len)) {
+		pru_virtqueue_add_used_buf(virtqueue, head, 0);
+		pru_virtqueue_kick(virtqueue);
+		return PRU_RPMSG_BUF_TOO_SMALL;
+	}
 
 	/* Copy local data buffer to the descriptor buffer address */
 	memcpy(msg->data, data, len);
@@ -144,8 +151,16 @@ int16_t pru_rpmsg_receive(
 	head = pru_virtqueue_get_avail_buf(virtqueue, (void **)&msg, &msg_len);
 
 	if (head < 0)
-		return PRU_RPMSG_NO_BUF_AVAILABLE;
+		return (head == PRU_VIRTQUEUE_INVALID_HEAD) ?
+			PRU_RPMSG_INVALID_HEAD : PRU_RPMSG_NO_BUF_AVAILABLE;
 
+	if (msg_len < sizeof(struct pru_rpmsg_hdr) ||
+	    msg->len > (msg_len - sizeof(struct pru_rpmsg_hdr)) ||
+	    msg->len > *len) {
+		pru_virtqueue_add_used_buf(virtqueue, head, msg_len);
+		pru_virtqueue_kick(virtqueue);
+		return PRU_RPMSG_BUF_TOO_SMALL;
+	}
 
 	/* Copy the message payload to the local data buffer provided */
 	memcpy(data, msg->data, msg->len);

--- a/source/rpmsg/pru_virtqueue.c
+++ b/source/rpmsg/pru_virtqueue.c
@@ -56,6 +56,13 @@ volatile register uint32_t __R31;
  */
 #define INT_OFFSET	16
 
+static inline void pru_virtqueue_memory_barrier(void)
+{
+#ifdef __GNUC__
+	__asm__ __volatile__ ("" : : : "memory");
+#endif
+}
+
 void pru_virtqueue_init(
 	struct pru_virtqueue 		*vq,
 	struct fw_rsc_vdev_vring 	*vring,
@@ -91,7 +98,12 @@ int16_t pru_virtqueue_get_avail_buf(
 	 * Grab the next descriptor number the ARM host is advertising, and
 	 * increment the last available index we've seen.
 	 */
-	head = avail->ring[vq->last_avail_idx++ & (vq->vring.num - 1)];
+	head = avail->ring[vq->last_avail_idx & (vq->vring.num - 1)];
+
+	if ((uint32_t)head >= vq->vring.num)
+		return PRU_VIRTQUEUE_INVALID_HEAD;
+
+	vq->last_avail_idx++;
 
 	desc = vq->vring.desc[head];
 	*buf = (void *)(uint32_t)desc.addr;
@@ -113,16 +125,18 @@ int16_t pru_virtqueue_add_used_buf(
 	num = vq->vring.num;
 	used = vq->vring.used;
 
-	if ((uint32_t)head > num)
+	if (head < 0 || (uint32_t)head >= num)
 		return PRU_VIRTQUEUE_INVALID_HEAD;
 
 	/*
 	 * The virtqueue's vring contains a ring of used buffers.  Get a pointer to
 	 * the next entry in that used ring.
 	 */
-	used_elem = &used->ring[used->idx++ & (num - 1)];
+	used_elem = &used->ring[used->idx & (num - 1)];
 	used_elem->id = head;
 	used_elem->len = len;
+	pru_virtqueue_memory_barrier();
+	used->idx++;
 
 	return PRU_VIRTQUEUE_SUCCESS;
 }

--- a/source/rpmsg/pru_virtqueue.c
+++ b/source/rpmsg/pru_virtqueue.c
@@ -60,6 +60,13 @@ static inline void pru_virtqueue_memory_barrier(void)
 {
 #ifdef __GNUC__
 	__asm__ __volatile__ ("" : : : "memory");
+#else
+	/* TI clpru (non-GNU): an empty asm() statement is treated as a
+	 * volatile optimization barrier; the compiler will not reorder
+	 * memory accesses across it. On the in-order PRU core (no hardware
+	 * store reordering) this is sufficient to guarantee the used-ring
+	 * entry is published before used->idx is incremented. */
+	__asm(" ");
 #endif
 }
 


### PR DESCRIPTION
## Summary
- Validate RPMsg send descriptors before copying payload data into virtqueue buffers
- Validate RPMsg receive descriptor size, payload size, and caller buffer capacity before copying into the caller buffer
- Tighten virtqueue descriptor head bounds checks and publish used-ring entries before incrementing `used->idx`
- Update RPMsg examples to pass the receive buffer capacity through `len` before each receive call

Fixes #100.

## Verification
- `git show --check --stat ea33ad99`
- Host GCC syntax check of `source/rpmsg/pru_rpmsg.c` and `source/rpmsg/pru_virtqueue.c` with a temporary `pru/io.h` stub; only expected 64-bit host pointer-size warnings from existing PRU address casts
- Fork Makefile CI: https://github.com/pratheesh/open-pru/actions/runs/27571640508
- Fork CCS Build: https://github.com/pratheesh/open-pru/actions/runs/27571640514
- Fork GNU Toolchain CI: https://github.com/pratheesh/open-pru/actions/runs/27571640515

## Notes
- This intentionally keeps the existing `pru_rpmsg_receive()` `uint16_t *src` / `uint16_t *dst` API to avoid an ABI/API break. The issue's width question remains a possible follow-up if maintainers want a breaking API update.
