### PR TITLE
examples: pru_i2c: wire firmware into top-level build (fixes am261x CI)

### DIFF
--- a/examples/makefile
+++ b/examples/makefile
@@ -3,7 +3,7 @@ include ../imports.mak
 SUBDIRS := \
     custom_frequency_generator empty empty_c \
     fft/split_radix_fft_4k_single_core fft/split_radix_fft_post_processing \
-    LCD_interface logic_scope pru_emif spi_loopback \
+    LCD_interface logic_scope pru_emif pru_i2c spi_loopback \
     fir multicore_scheduler rpmsg_echo_linux
 
 # "make" or "make all" builds projects that match $(DEVICE) set in imports.mak

--- a/examples/pru_i2c/makefile
+++ b/examples/pru_i2c/makefile
@@ -1,0 +1,94 @@
+include ../../imports.mak
+
+#######################
+# project information #
+#######################
+
+PROJECT_NAME := pru_i2c
+SUPPORTED_PROCESSORS := am261x
+# Does the PRU code have dependencies outside of the open-pru repo?
+PRU_DEPENDENCIES :=
+# Use NON_PRU_DEPENDENCIES to select which makefiles to call for non-PRU cores
+NON_PRU_DEPENDENCIES :=
+
+###################
+# Prebuild checks #
+###################
+BUILD_PROJECT := y
+DEVICE_NON_PRU :=
+
+# Only build project if $(DEVICE) is in $(SUPPORTED_PROCESSORS)
+ifeq (,$(findstring $(DEVICE),$(SUPPORTED_PROCESSORS)))
+BUILD_PROJECT := n
+MESSAGE := Project $(PROJECT_NAME) does not have a build option for $(DEVICE)
+endif
+
+# Only build project if PRU dependencies exist
+ifneq (,$(PRU_DEPENDENCIES))
+# MCU+ SDK dependency?
+ifeq (mcuplus,$(findstring mcuplus,$(PRU_DEPENDENCIES)))
+ifneq ($(BUILD_MCUPLUS),y)
+BUILD_PROJECT := n
+MESSAGE ?= Project $(PROJECT_NAME) depends on MCU+ SDK, but BUILD_MCUPLUS != y.
+endif
+endif
+endif
+
+# Only build non-PRU code if the non-PRU code is enabled in imports.mak
+ifeq ($(BUILD_MCUPLUS),y)
+ifeq (mcuplus,$(findstring mcuplus,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_mcuplus
+endif
+endif
+ifeq ($(BUILD_LINUX),y)
+ifeq (linux,$(findstring linux,$(NON_PRU_DEPENDENCIES)))
+DEVICE_NON_PRU += $(DEVICE)_linux
+endif
+endif
+
+###########################
+# Make and clean commands #
+###########################
+
+ifeq ($(BUILD_PROJECT),y)
+# "make" or "make all" builds projects that match $(DEVICE) set in imports.mak
+# "make" builds PRU firmware first, then host (non-PRU) code
+all: MESSAGE = "Building $(PROJECT_NAME) for $(DEVICE)"
+all: pre_build_message
+	$(MAKE) pru
+	$(MAKE) host
+
+# "make pru" builds only PRU firmware for $(DEVICE)
+pru: ARGUMENTS_PRU = all
+pru: $(DEVICE)
+
+# "make host" builds only host (non-PRU) code for $(DEVICE)
+host: ARGUMENTS_MCUPLUS = all
+host: $(DEVICE_NON_PRU)
+
+# "make clean" cleans projects that match $(DEVICE) set in imports.mak
+clean: ARGUMENTS_PRU = clean
+clean: ARGUMENTS_MCUPLUS = scrub
+clean: MESSAGE = "Cleaning $(PROJECT_NAME) for $(DEVICE)"
+clean: pre_build_message $(DEVICE) $(DEVICE_NON_PRU)
+
+else
+# if a prebuild check failed, print message and exit
+all clean pru host: pre_build_message
+endif
+
+pre_build_message:
+	@echo $(MESSAGE)
+
+######################
+# Target definitions #
+######################
+
+# provide target definitions for each supported processor
+# PRU firmware should be built before any RTOS code that includes it
+am261x:
+# am261x-lp
+	$(MAKE) -C firmware/am261x-lp/icss_m0_pru0_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+	$(MAKE) -C firmware/am261x-lp/icss_m0_pru1_fw/ti-pru-cgt $(ARGUMENTS_PRU)
+
+.PHONY: all clean pru host pre_build_message $(DEVICE) $(DEVICE_NON_PRU) $(SUPPORTED_PROCESSORS)


### PR DESCRIPTION
Follow-up to #137 — meant to fold directly into that PR's branch (`a0502729_PRU_I2C`).

The am261x **"Verify all makefiles were built"** CI step on #137 fails with `makefile never built` for the two pru_i2c PRU firmware makefiles, because nothing in the top-level make recurses into them.

This single commit fixes that:

- Adds `examples/pru_i2c/makefile` aggregator (modeled on `examples/empty`), scoped to am261x with an am261x target that builds the pru0/pru1 ti-pru-cgt firmware. Non-am261x devices hit the `SUPPORTED_PROCESSORS` prebuild check and skip cleanly, so other device builds are unaffected.
- Adds `pru_i2c` to `examples/makefile` SUBDIRS so the top-level make recurses into it.

Verified with GNU Make dry-runs: am261x recurses into both firmware leaf makefiles (each producing a `.out`, satisfying the verify step); am263x prints "does not have a build option" and builds nothing.

@achala-ti — feel free to merge this into your branch (or cherry-pick `e18657d8`) so #137's CI goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)