### PR TITLE
docs: exempt tool-generated SysConfig files from column-length limits

### DIFF
--- a/best_practices.md
+++ b/best_practices.md
@@ -402,6 +402,8 @@ Key conventions:
 - Copyright header is required on all source files (see General Remarks).
 - Use FIXME (not TODO) for pending work markers.
 - Column limits: no text beyond column 79 (soft), column 129 (hard).
+  Tool-generated files (for example SysConfig `*.syscfg` files) are exempt; see
+  General Remarks rule 11.
 
 ## C Code Best Practices (MCU+ Host Cores)
 
@@ -612,12 +614,18 @@ m_test_assert .macro condition, error_code
 8. Use "for example" instead of "e.g.".
 9. Use "that is" instead of "i.e.".
 10. Use "and so on" instead of "etc,".
-11. No text beyond column 79 in source files (does not apply to markdown docs or .txt docs).
+11. No text beyond column 79 in hand-written source files (does not apply to
+    markdown docs, .txt docs, or tool-generated files).
     - Column 79 is the "soft" limit.
     - Long lines of code are more difficult to follow and interrupt code flow.
     - There shall be no text beyond column 129.
     - This is the "hard" limit.
     - Lines longer than column 79 should be the exceptional case in any source file.
+    - Tool-generated files are exempt from both the soft and hard limits, since
+      their formatting is owned by the generating tool and cannot be wrapped by
+      hand. This notably includes SysConfig `*.syscfg` files, whose
+      `@cliArgs`/`@v2CliArgs` header lines are emitted as single-line command
+      strings that exceed column 129 by construction.
 
 ## Files
 1. The extension for clpru (CGT PRU) source files shall be ".asm".


### PR DESCRIPTION
## Problem

`best_practices.md` defines a 79-soft / 129-hard column limit. The automated reviewer (Qodo) applies this rule to **SysConfig `example.syscfg` files**, which are machine-generated. Their `@cliArgs` / `@v2CliArgs` header lines are single-line command strings (typically 140–165 cols) that **exceed column 129 by construction** and cannot be wrapped without breaking SysConfig's round-trip parsing.

This produces false-positive "rule violation" flags on any PR that so much as touches a `.syscfg` file. Concrete example: PR #140 (issue #108) only swapped the `OPEN_PRU@<ver>` token *inside* pre-existing long generated lines, yet was flagged for a 129-column violation it neither introduced nor can fix.

Note the repo's own CI does not enforce this limit on generated files (the column check in `makefile.yml` is commented out), so this is purely a documentation/review-guidance gap.

## Change

Make the existing carve-out explicit. The rule already exempts markdown and `.txt` docs; this adds **tool-generated files** (notably SysConfig `*.syscfg`) to that same exemption, in both places the limit is stated:

- The PRU C firmware "Key conventions" summary.
- General Remarks rule 11, with a short rationale.

No source or build behavior changes — documentation only.

## Why this is the right scope

The limit exists to keep *hand-written* code readable. Generated files are owned by their tool; flagging them as violations creates noise that trains reviewers (human and automated) to ignore the rule. Exempting them keeps the limit meaningful where it matters.