### PR TITLE
docs: add PRU-ICSS documentation map (per-device TRM / addendum / instruction pointers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ folder of the `open-pru` repository.
   - [AM263Px](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263PX/latest/exports/docs/api_guide_am263px/CCS_PROJECTS_PAGE.html)
   - [AM263x](https://software-dl.ti.com/mcu-plus-sdk/esd/AM263X/latest/exports/docs/api_guide_am263x/CCS_PROJECTS_PAGE.html)
 
+## PRU-ICSS documentation references
+
+There is no standalone *PRU-ICSS Reference Guide* (SPRUHF8A) for the Sitara MCUs
+supported here — the PRU-ICSS(M/G) subsystem is documented as a chapter of each
+device Technical Reference Manual, plus the device register addendum and the
+common PRU Assembly Instruction User Guide. See the
+[PRU-ICSS Documentation Map](./docs/pru_icss_documentation_map.md) for the
+per-device TRM / register addendum / instruction-set pointers.
+
 ## Using EVM boards
 
 Please note that different EVMs have different signals pinned out. Before

--- a/docs/pru_icss_documentation_map.md
+++ b/docs/pru_icss_documentation_map.md
@@ -1,0 +1,59 @@
+# PRU-ICSS Documentation Map
+
+Developers coming to the PRU from the AM335x generation often look for a single,
+standalone *PRU-ICSS Reference Guide* (SPRUHF8A). For the Sitara MCUs supported
+by OpenPRU there is **no direct SPRUHF8A equivalent** — and that is by design.
+
+The AM335x device integrates a **first-generation PRU-ICSS**, which SPRUHF8A
+documents as a standalone guide. The AM26x devices (AM261x, AM263x, AM263Px)
+integrate a later-generation, MCU-oriented **PRU-ICSSM**, and the AM24x/AM64x
+devices integrate the **PRU-ICSSG** variant. For all of these, the PRU-ICSS(M/G)
+subsystem is documented as a **chapter of the device Technical Reference Manual
+(TRM)**, complemented by the device **Register Addendum** for the full register
+map, and by the common **PRU Assembly Instruction User Guide** for the
+instruction set.
+
+This page maps each supported device to its authoritative references.
+
+## Per-device references
+
+| Device family | Technical Reference Manual (contains the PRU-ICSS chapter) | Register Addendum | PRU assembly instruction set |
+| --- | --- | --- | --- |
+| AM263Px       | [SPRUJ55](https://www.ti.com/lit/ug/spruj55/spruj55.pdf) | AM263Px Register Addendum (search "AM263Px Register Addendum" on ti.com) | [SPRUIJ2](https://www.ti.com/lit/ug/spruij2/spruij2.pdf) |
+| AM263x        | [SPRUJ17](https://www.ti.com/lit/ug/spruj17/spruj17.pdf) | [SPRUJ42](https://www.ti.com/lit/ug/spruj42/spruj42.pdf) | [SPRUIJ2](https://www.ti.com/lit/ug/spruij2/spruij2.pdf) |
+| AM261x        | [SPRUJB6](https://www.ti.com/lit/ug/sprujb6/sprujb6.pdf) | AM261x Register Addendum (search "AM261x Register Addendum" on ti.com) | [SPRUIJ2](https://www.ti.com/lit/ug/spruij2/spruij2.pdf) |
+| AM243x / AM64x | [SPRUIM2](https://www.ti.com/lit/ug/spruim2/spruim2.pdf) | device Register Addendum (search on ti.com) | [SPRUIJ2](https://www.ti.com/lit/ug/spruij2/spruij2.pdf) |
+
+> Literature numbers are the base (un-revisioned) identifiers. TI serves the
+> latest revision from the un-suffixed URL (for example `spruj55.pdf`); append a
+> revision letter for a specific revision (for example `spruj55d.pdf`). Always
+> confirm you are reading the latest revision for your silicon.
+
+## How to find the PRU-ICSS content inside a TRM
+
+Within the device TRM, the relevant material lives under the
+**PRU-ICSS / PRU_ICSSM / PRU_ICSSG** chapter, which typically covers:
+
+- Subsystem overview, memory map, and integration
+- PRU cores, register files (`R30` output / `R31` input), and the constant table
+- Interrupt controller (INTC) and event mapping
+- Peripherals in the subsystem (IEP, MII_RT/MDIO where applicable, UART, etc.)
+- Local INTC / interrupt connections
+
+For the register-level detail (bit fields, offsets, reset values) use the
+device **Register Addendum** alongside the TRM chapter.
+
+## Instruction set
+
+The PRU assembly instruction set is common across these devices and is
+documented in the **PRU Assembly Instruction User Guide (SPRUIJ2)**. A quick
+reference is also maintained in this repository:
+[PRU Assembly Instruction Cheat Sheet](./PRU%20Assembly%20Instruction%20Cheat%20Sheet.md).
+
+## Why there is no SPRUHF8A for these parts
+
+SPRUHF8A documents the **first-generation PRU-ICSS** on AM335x. The OpenPRU
+target devices use the later **PRU-ICSSM** (AM26x) and **PRU-ICSSG** (AM24x/AM64x)
+generations, whose documentation was integrated into the device TRM + register
+addendum model rather than published as a separate subsystem reference guide.
+The mapping above is the equivalent starting point.


### PR DESCRIPTION
## What

Adds a **PRU-ICSS documentation map** (`docs/pru_icss_documentation_map.md`) and links it from the README.

## Why

Developers coming from the AM335x generation expect a standalone *PRU-ICSS Reference Guide* (SPRUHF8A) and don't find one for the currently supported Sitara MCUs — the content now lives in the device TRM chapter + register addendum + the common PRU Assembly Instruction User Guide. This is a recurring E2E question (e.g. thread 1665810, *"AM263P4 PRU-ICSS: Is there a Technical Reference Manual equivalent to SPRUHF8A?"*).

## What's in the doc

- Per-device table mapping each supported family to its TRM, register addendum, and instruction guide:
  - AM263Px → SPRUJ55
  - AM263x → SPRUJ17 (+ addendum SPRUJ42)
  - AM261x → SPRUJB6
  - AM243x / AM64x → SPRUIM2
  - Instruction set (all) → SPRUIJ2
- Note on revision-suffix URLs (base vs revisioned literature numbers).
- A short "how to find the PRU-ICSS content inside a TRM" section.
- Explanation that there is no SPRUHF8A equivalent by design: AM335x is first-gen PRU-ICSS, whereas the supported parts use the later PRU-ICSSM (AM26x) / PRU-ICSSG (AM24x/AM64x) generations.

Documentation only — no code changes.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
